### PR TITLE
Added support for Altera OpenCL

### DIFF
--- a/src/arch/opencl/openclprocessor_decl.hpp
+++ b/src/arch/opencl/openclprocessor_decl.hpp
@@ -158,7 +158,7 @@ public:
    std::string getDeviceName();
    std::string getDeviceVendor();
    
-   
+   bool outOfOrderSupport(); 
 
 public:
    cl_int getDeviceType( cl_device_type &deviceType )


### PR DESCRIPTION
- Changes
  - The OpenCL version check now detects Altera OpenCL  1.0
  - Altera OpenCL don't support out of order queues. Added a check to avoid them.
  - Altera OpenCL task can't execute asynchronous. Added a check to do it synchronous
  - Bug fix : Error checking for clEnqueueNDRangeKernel was done after clWaitForEvent causing a deadlock
