### PR TITLE
Add size field to BaseDependency and subclasses

### DIFF
--- a/src/core/address.hpp
+++ b/src/core/address.hpp
@@ -44,7 +44,10 @@ inline bool Address::operator== ( const Address &obj ) const
 inline bool Address::overlap ( const BaseDependency &obj ) const
 {
    const Address& address( static_cast<const Address&>( obj ) );
-   return _address == address._address;
+   if ( _address <= address._address )
+      return address._address < reinterpret_cast<const void *>( reinterpret_cast<const char *>( _address ) + _size );
+   
+   return _address < reinterpret_cast<const void *>( reinterpret_cast<const char *>( address._address ) + address._size);
 }
 
 inline bool Address::operator< ( const Address &obj ) const

--- a/src/core/address.hpp
+++ b/src/core/address.hpp
@@ -57,7 +57,7 @@ inline bool Address::operator< ( const Address &obj ) const
 
 inline BaseDependency* Address::clone() const
 {
-   return new Address( _address );
+   return new Address( _address, _size );
 }
 
 inline void * Address::getAddress () const

--- a/src/core/address.hpp
+++ b/src/core/address.hpp
@@ -27,6 +27,7 @@ namespace nanos {
 inline const Address & Address::operator= ( const Address &obj )
 {
    _address = obj._address;
+   _size = obj._size;
    return *this;
 }
 
@@ -59,6 +60,16 @@ inline BaseDependency* Address::clone() const
 inline void * Address::getAddress () const
 {
    return _address;
+}
+
+inline size_t Address::size() const
+{
+  return _size;
+}
+
+inline void Address::size ( size_t s )
+{
+  _size = s;
 }
 
 } // namespace nanos

--- a/src/core/address_decl.hpp
+++ b/src/core/address_decl.hpp
@@ -34,19 +34,20 @@ namespace nanos {
          typedef void*           TargetType;
       private:
          TargetType              _address; /**< Pointer to the dependency address */
+         size_t                  _size; /**< Size in bytes of the dependency object */
       public:
 
         /*! \brief Address default constructor
          *  Creates an Address with the given address associated.
          */
-         Address ( TargetType address = NULL )
-            : _address( address ) {}
+         Address ( TargetType address = NULL, size_t s = 1 )
+            : _address( address ), _size( s ) {}
 
         /*! \brief Address copy constructor
          *  \param obj another Address
          */
          Address ( const Address &obj ) 
-            :  BaseDependency(), _address ( obj._address ) {}
+            :  BaseDependency(), _address ( obj._address ), _size( obj._size ) {}
 
         /*! \brief Address destructor
          */
@@ -73,6 +74,12 @@ namespace nanos {
 
          //! \brief Returns dependence base address
          virtual void * getAddress () const;
+
+         //! \brief Returns the size of the dependency object.
+         virtual size_t size() const;
+
+         //! \brief Returns the size of the dependency object.
+         virtual void size ( size_t s );
          
         /*! \brief Overlap operator.
          */

--- a/src/core/basedependency_decl.hpp
+++ b/src/core/basedependency_decl.hpp
@@ -42,6 +42,9 @@ namespace nanos {
 
          //! \brief Returns dependency base address
          virtual void * getAddress () const = 0;
+
+         //! \brief Returns the size of the dependency object.
+         virtual size_t size() const { return 1; }
                   
         /*! \brief Check if two dependencies overlap/collide.
          */

--- a/src/plugins/deps/plain_deps.cpp
+++ b/src/plugins/deps/plain_deps.cpp
@@ -100,6 +100,11 @@ namespace nanos {
                   // if address == NULL, just ignore it
                   if ( target() == NULL ) continue;
                   AccessType const &accessType = dep.flags;
+		  size_t size = 1;
+		  for (short i = 0; i < dep.dimension_count; ++i) {
+		    size *= dep.dimensions[i].size;
+		  }
+		  target.size(size);
 
                   submitDependableObjectDataAccess( depObj, target, accessType, callback );
                   flushDeps.push_back( (uint64_t) target() );


### PR DESCRIPTION
The idea is to be able to retrieve the number of bytes of a `BaseDependency` object. This can be useful for scheduling purposes; right now it is not possible to access this information from outside the dependency manager.

Commit 37987ac adds a virtual method to retrieve the size for `BaseDependency` returning 1 by default, implements it in `Address` using a new `_size` field and a setter method. The `plain` dependency manager is extended to set this value; other managers should be updated accordingly. Maybe a new option in `NX_ARGS` should be added to manually enable this feature, since it adds linear overhead in the number of dimensions for each dependency. Considering the number of dimensions is upper-bounded, this becomes linear in the number of dependencies (which is not that bad).

Commit 158dae5 extends the `Address::overlap(...)` method to use the size in the calculation. This calculation will make sense as long as the data is contiguous. Of course, this changes a bit the way `plain` works and maybe fits better in a new class for a new dependency manager.