### PR TITLE
Include depsregion.hpp and depsregion_decl.hpp in devinclude_HEADERS.

### DIFF
--- a/src/support/Makefile.am
+++ b/src/support/Makefile.am
@@ -103,6 +103,8 @@ devinclude_HEADERS = \
 	smartpointer.hpp \
 	memory/memoryaddress.hpp \
 	concurrent_queue.hpp \
+	depsregion.hpp \
+	depsregion_decl.hpp \
 	$(END) 
 
 support_sources = \
@@ -224,7 +226,7 @@ gpu_support_sources = \
 	pinnedallocator.cpp \
         $(END)
 endif
-	
+
 
 noinst_LTLIBRARIES =
 


### PR DESCRIPTION
`depsregion.hpp` and `depsregion_decl.hpp` are missing in `$prefix/include/nanox-dev` after installing. This commit adds them to `devinclude_HEADERS` so they get installed.