### PR TITLE
In schedulers where batch queue is not implemented, use default.

### DIFF
--- a/src/plugins/sched/affinity-ready_sched.cpp
+++ b/src/plugins/sched/affinity-ready_sched.cpp
@@ -37,6 +37,7 @@ namespace nanos {
 
          public:
             typedef std::set<ThreadData *> ThreadDataSet;
+            using SchedulePolicy::queue;
 
          private:
 
@@ -533,12 +534,6 @@ namespace nanos {
                }
 
                tdata._queues->globalPushBack( &wd );
-            }
-
-
-            virtual void queue ( BaseThread ** threads, WD ** wds, size_t numElems )
-            {
-               fatal ( "This method is not implemented yet" );
             }
 
             /*!

--- a/src/plugins/sched/affinity_sched.cpp
+++ b/src/plugins/sched/affinity_sched.cpp
@@ -511,6 +511,9 @@ namespace nanos {
 
       class CacheSchedPolicy : public SchedulePolicy
       {
+         public:
+            using SchedulePolicy::queue;
+        
          private:
 
             struct TeamData : public ScheduleTeamData
@@ -1346,11 +1349,6 @@ namespace nanos {
 
                } //not rooted wd
 #endif
-            }
-
-            virtual void queue ( BaseThread ** threads, WD ** wds, size_t numElems )
-            {
-               fatal( "This method is not implemented yet" );
             }
 
             /*!

--- a/src/plugins/sched/botlev_sched.cpp
+++ b/src/plugins/sched/botlev_sched.cpp
@@ -113,6 +113,7 @@ namespace nanos {
       class BotLev : public SchedulePolicy
       {
          public:
+            using SchedulePolicy::queue;
             typedef std::stack<BotLevDOData *>   bot_lev_dos_t;
             typedef std::set<std::pair< unsigned int, DependableObject * > > DepObjVector; /**< Type vector of successors  */
 
@@ -292,11 +293,6 @@ namespace nanos {
       
 #endif
                 return;
-            }
-
-            virtual void queue ( BaseThread ** threads, WD ** wds, size_t numElems )
-            {
-               fatal( "This method is not implemented yet" );
             }
 
             void updateBottomLevels( BotLevDOData *dodata, int botLev )

--- a/src/plugins/sched/dbf_sched.cpp
+++ b/src/plugins/sched/dbf_sched.cpp
@@ -28,6 +28,7 @@ namespace nanos {
       class DistributedBFPolicy : public SchedulePolicy
       {
          public:
+            using SchedulePolicy::queue;
             static bool       _usePriority;
             static bool       _useSmartPriority;
          private:
@@ -134,11 +135,6 @@ namespace nanos {
                   data._readyQueue->push_front( &wd );
                   sys.getThreadManager()->unblockThread(thread);
                }
-            }
-
-            virtual void queue ( BaseThread ** threads, WD ** wds, size_t numElems )
-            {
-               fatal( "This method is not implemented yet" );
             }
 
             /*!

--- a/src/plugins/sched/socket_sched.cpp
+++ b/src/plugins/sched/socket_sched.cpp
@@ -55,6 +55,9 @@ namespace nanos {
       {
          public:
             const static int UnassignedNode =-1; //!< Value returned by getNode() when it does not find a suitable nod
+
+            using SchedulePolicy::queue;         //!< Load default implementation of queue prior to redefinition
+            using SchedulePolicy::successorFound;//!< Load default implementation of successorFound
          
          private:
             bool _steal;                         //!< Steal work from other sockets?
@@ -536,11 +539,6 @@ namespace nanos {
             {
                socketQueue( thread, wd, false );
             }
-
-            virtual void queue ( BaseThread ** threads, WD ** wds, size_t numElems )
-            {
-               fatal( "This method is not implemented yet" );
-            }
             
             /*!
              *  \brief Queues a work descriptor in a readyQueue.
@@ -847,10 +845,6 @@ namespace nanos {
                      tdata._readyQueues[ index ].reorderWD( pred );
                   }
                }
-            }
-            
-            virtual void successorFound( DependableObject *predecessor, DependableObject *successor ) {
-                fatal( "This method is not implemented yet" );
             }
 
             //! \brief Enables or disables stealing

--- a/src/plugins/sched/versioning_sched.cpp
+++ b/src/plugins/sched/versioning_sched.cpp
@@ -252,6 +252,8 @@ namespace ext
 
    class Versioning : public SchedulePolicy
    {
+      public:
+         using SchedulePolicy::queue;
       private:
          struct TeamData : public ScheduleTeamData
          {
@@ -424,11 +426,6 @@ namespace ext
          {
             TeamData &tdata = ( TeamData & ) *thread->getTeam()->getScheduleData();
             tdata._readyQueue->push_back( &wd );
-         }
-
-         virtual void queue ( BaseThread ** threads, WD ** wds, size_t numElems )
-         {
-            fatal( "This method is not implemented yet" );
          }
 
          virtual WD *atSubmit ( BaseThread *thread, WD &newWD )

--- a/src/plugins/sched/wf_sched.cpp
+++ b/src/plugins/sched/wf_sched.cpp
@@ -28,6 +28,8 @@ namespace nanos {
 
       class WorkFirst : public SchedulePolicy
       {
+         public:
+            using SchedulePolicy::queue;
          private:
             struct ThreadData : public ScheduleThreadData
             {
@@ -95,11 +97,6 @@ namespace nanos {
             {
                 ThreadData &data = ( ThreadData & ) *thread->getTeamData()->getScheduleData();
                 data._readyQueue.push_front ( &wd );
-            }
-
-            virtual void queue ( BaseThread ** threads, WD ** wds, size_t numElems )
-            {
-               fatal( "This method is not implemented yet" );
             }
 
             /*!


### PR DESCRIPTION
In order to solve some ICC errors regarding partial overloads, commit ad9f248b added a definition for the batch-mode `queue` method in classes not manually implementing it that called `fatal`. This causes such schedulers not to work at all. The base `SchedulePolicy` class has a default method implementation which should generally work with all schedule policies, so this branch changes that implementation with a `using SchedulePolicy::queue` clause that tells the compiler to use the default implementation of `queue` (unless overloaded).

Doing specific implementations of the method would be preferred, I suppose, but this is a fast solution that should work for (most of) the other scheduler policies.