### PR TITLE
Fix < operator so that DepsRegion can be used as key in std::map

### DIFF
--- a/src/support/depsregion.hpp
+++ b/src/support/depsregion.hpp
@@ -50,6 +50,9 @@ inline bool DepsRegion::overlap ( const BaseDependency &obj ) const
  
 inline bool DepsRegion::operator< ( const DepsRegion &obj ) const
 {
+   if(_address == obj._address) {
+      return _endAddress < obj._endAddress;
+   }
    return _address < obj._address;
 }
 


### PR DESCRIPTION
By default STL will use the < operator for the key type when inserting or looking up a key/value pair in std::map.  DepsRegion has an overridden < operator and is used as a key value in a few maps in the cregions plugin. However the operator didn't take account of the end address of the region. This caused funky things to happen.