### PR TITLE
tg-dump plugin initial implementation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -153,6 +153,9 @@ AX_ENABLE_TASK_CALLBACK
 # Extrae check
 AX_CHECK_EXTRAE
 
+# Papi check
+AX_CHECK_PAPI
+
 # Check NextSim support
 AC_ARG_WITH([nextsim],
            AS_HELP_STRING([--with-nextsim=dir], [Directory of NextSim installation]),

--- a/m4/ax_check_papi.m4
+++ b/m4/ax_check_papi.m4
@@ -1,0 +1,92 @@
+#####################################################################################
+#      Copyright 2009-2018 Barcelona Supercomputing Center                          #
+#                                                                                   #
+#      This file is part of the NANOS++ library.                                    #
+#                                                                                   #
+#      NANOS++ is free software: you can redistribute it and/or modify              #
+#      it under the terms of the GNU Lesser General Public License as published by  #
+#      the Free Software Foundation, either version 3 of the License, or            #
+#      (at your option) any later version.                                          #
+#                                                                                   #
+#      NANOS++ is distributed in the hope that it will be useful,                   #
+#      but WITHOUT ANY WARRANTY; without even the implied warranty of               #
+#      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                #
+#      GNU Lesser General Public License for more details.                          #
+#                                                                                   #
+#      You should have received a copy of the GNU Lesser General Public License     #
+#      along with NANOS++.  If not, see <https://www.gnu.org/licenses/>.            #
+#####################################################################################
+
+#
+# SYNOPSIS
+#
+#   AX_CHECK_PAPI
+#
+# DESCRIPTION
+#
+#   Check hardware counter support with PAPI
+#
+
+AC_DEFUN([AX_CHECK_PAPI],
+[
+   PAPI_INC=""
+   PAPI_LIB=""
+
+   AC_MSG_CHECKING([for PAPI])
+   AC_ARG_WITH([papi],
+      [AS_HELP_STRING([--with-papi@<:@=DIR@:>@], [build with PAPI library support])],
+      [], dnl Implicit: with_papi=$withvalue
+      [with_papi=no]
+   )
+   AC_MSG_RESULT([$with_papi])
+
+   AS_IF([test "x$with_papi" != xno], [
+      AS_IF([test -d "$with_papi"], [
+         AS_IF([test -d "$with_papi/include"], [papicppflags="-I$with_papi/include"])
+         AS_IF([test -d "$with_papi/lib"], [papildflags="-L$with_papi/lib"])
+      ])
+
+      ### PAPI INCLUDES
+      AC_LANG_PUSH([C++])
+      AX_VAR_PUSHVALUE([CPPFLAGS], [$papicppflags])
+      AC_CHECK_HEADERS([papi.h], [
+         # header found, do nothing
+      ], [
+         AS_IF([test "x$with_papi" != xcheck], [AC_MSG_ERROR([Cannot find PAPI headers])])
+         with_papi=no
+      ])
+      AX_VAR_POPVALUE([CPPFLAGS])
+      AC_LANG_POP([C++])
+   ])
+
+   AS_IF([test "x$with_papi" != xno], [
+      ### PAPI LIBS
+      AC_LANG_PUSH([C++])
+      AX_VAR_PUSHVALUE([LIBS], [""])
+      AX_VAR_PUSHVALUE([LDFLAGS], [$papildflags])
+      AC_SEARCH_LIBS([PAPI_library_init], [papi], [
+         papilibs="$LIBS"
+      ], [
+         AS_IF([test "x$with_papi" != xcheck], [AC_MSG_ERROR([Cannot find PAPI libraries])])
+         with_papi=no
+      ])
+      AX_VAR_POPVALUE([LDFLAGS])
+      AX_VAR_POPVALUE([LIBS])
+      AC_LANG_POP([C++])
+   ])
+
+   AS_IF([test "x$with_papi" != xno], [
+      AC_DEFINE([PAPI],[],[Enables PAPI support.])
+      AC_SUBST([HAVE_PAPI], [PAPI])
+      PAPI_INC="$withval/include"
+      PAPI_LIB="$withval/lib"
+   ], [
+      AC_SUBST([HAVE_PAPI], [NO_PAPI])
+   ])
+   
+   AC_SUBST([PAPI_INC])
+   AC_SUBST([PAPI_LIB])
+   
+   # If papi is present, compile the tgdump instrumentation plugin
+   AM_CONDITIONAL([instrumentation_TGDUMP], test "x$with_papi" != xno)
+])

--- a/src/core/instrumentation_decl.hpp
+++ b/src/core/instrumentation_decl.hpp
@@ -675,8 +675,8 @@ namespace nanos {
             /* 71 */ registerEventKey("cache-evict", "Cache eviction", false, EVENT_ADVANCED);
             /* 72 */ registerEventKey("copy-data-alloc","Cache allocation", false, EVENT_ADVANCED);
 
-            /* 73 */ registerEventKey("dep-range-start", "Beginning of memory range implied by a dependency", true, EVENT_DEVELOPER );
-            /* 74 */ registerEventKey("dep-range-end", "End of memory range implied by a dependency", true, EVENT_DEVELOPER );
+            /* 73 */ registerEventKey("dep-overlap-start", "Beginning of memory range involved with a dependency", true, EVENT_DEVELOPER );
+            /* 74 */ registerEventKey("dep-overlap-end", "End of memory range involved with a dependency", true, EVENT_DEVELOPER );
 
             /* ** */ registerEventKey("debug","Debug Key", true, EVENT_ADVANCED ); /* Keep this key as the last one */
          }

--- a/src/core/instrumentation_decl.hpp
+++ b/src/core/instrumentation_decl.hpp
@@ -675,6 +675,8 @@ namespace nanos {
             /* 71 */ registerEventKey("cache-evict", "Cache eviction", false, EVENT_ADVANCED);
             /* 72 */ registerEventKey("copy-data-alloc","Cache allocation", false, EVENT_ADVANCED);
 
+            /* 73 */ registerEventKey("dep-size", "Number of bytes implied by dependency", true, EVENT_DEVELOPER );
+
             /* ** */ registerEventKey("debug","Debug Key", true, EVENT_ADVANCED ); /* Keep this key as the last one */
          }
 

--- a/src/core/instrumentation_decl.hpp
+++ b/src/core/instrumentation_decl.hpp
@@ -675,7 +675,8 @@ namespace nanos {
             /* 71 */ registerEventKey("cache-evict", "Cache eviction", false, EVENT_ADVANCED);
             /* 72 */ registerEventKey("copy-data-alloc","Cache allocation", false, EVENT_ADVANCED);
 
-            /* 73 */ registerEventKey("dep-size", "Number of bytes implied by dependency", true, EVENT_DEVELOPER );
+            /* 73 */ registerEventKey("dep-range-start", "Beginning of memory range implied by a dependency", true, EVENT_DEVELOPER );
+            /* 74 */ registerEventKey("dep-range-end", "End of memory range implied by a dependency", true, EVENT_DEVELOPER );
 
             /* ** */ registerEventKey("debug","Debug Key", true, EVENT_ADVANCED ); /* Keep this key as the last one */
          }

--- a/src/core/trackableobject.hpp
+++ b/src/core/trackableobject.hpp
@@ -124,6 +124,16 @@ inline bool TrackableObject::isEmpty ()
    return ( _lastWriter == 0 ) && _versionReaders.empty() && ( _commDO == 0 );
 }
 
+inline std::pair<void*, void*> TrackableObject::getDataRange() const 
+{
+   return _data_range;
+}
+
+inline void TrackableObject::setDataRange(std::pair<void*, void*> const data_range)
+{
+   _data_range = data_range;
+}
+
 inline bool TrackableObject::isOnHold () const
 {
    return _hold;

--- a/src/core/trackableobject.hpp
+++ b/src/core/trackableobject.hpp
@@ -124,14 +124,14 @@ inline bool TrackableObject::isEmpty ()
    return ( _lastWriter == 0 ) && _versionReaders.empty() && ( _commDO == 0 );
 }
 
-inline std::pair<void*, void*> TrackableObject::getDataRange() const 
+inline std::pair<void*, void*> TrackableObject::getOverlapRange() const 
 {
-   return _data_range;
+   return _overlapRange;
 }
 
-inline void TrackableObject::setDataRange(std::pair<void*, void*> const data_range)
+inline void TrackableObject::setOverlapRange(std::pair<void*, void*> const range)
 {
-   _data_range = data_range;
+   _overlapRange = range;
 }
 
 inline bool TrackableObject::isOnHold () const

--- a/src/core/trackableobject_decl.hpp
+++ b/src/core/trackableobject_decl.hpp
@@ -42,7 +42,7 @@ namespace nanos {
          Lock                     _writerLock; /**< Lock internally the object for secure access to _lastWriter */
          CommutationDO           *_commDO; /**< Will be successor of all commutation tasks using this object untill a new reader/writer appears */
          bool                     _hold; /**< Cannot be erased since it is in use */
-         std::pair<void*, void*>  _data_range; /**< Range of data associated with this trackable object */
+         std::pair<void*, void*>  _overlapRange; /**< Range of data associated with this trackable object, used by cregions deps plugin */
 
       public:
 
@@ -51,14 +51,14 @@ namespace nanos {
          *  Creates a TrackableObject with the given address associated.
          */
          TrackableObject ()
-            : _lastWriter ( NULL ), _versionReaders(), _readersLock(), _writerLock(), _commDO(NULL), _hold(false), _data_range(std::pair<void*, void*>(NULL, NULL)) {}
+            : _lastWriter ( NULL ), _versionReaders(), _readersLock(), _writerLock(), _commDO(NULL), _hold(false), _overlapRange(std::pair<void*, void*>(NULL, NULL)) {}
 
         /*! \brief TrackableObject copy constructor
          *
          *  \param obj another TrackableObject
          */
          TrackableObject ( const TrackableObject &obj ) 
-            :   _lastWriter ( obj._lastWriter ), _versionReaders(), _readersLock(), _writerLock(), _commDO(NULL), _hold(false), _data_range(std::pair<void*, void*>(NULL, NULL)) {}
+            :   _lastWriter ( obj._lastWriter ), _versionReaders(), _readersLock(), _writerLock(), _commDO(NULL), _hold(false), _overlapRange(std::pair<void*, void*>(NULL, NULL)) {}
 
         /*! \brief TrackableObject destructor
          */
@@ -152,11 +152,11 @@ namespace nanos {
          
         /*! \brief Returns the range of data associated with this trackable object
          */
-         std::pair<void*, void*> getDataRange() const;
+         std::pair<void*, void*> getOverlapRange() const;
          
         /*! \brief Returns the range of data associated with this trackable object
          */
-         void setDataRange(std::pair<void*, void*> const range);
+         void setOverlapRange(std::pair<void*, void*> const range);
    };
 
    //! \brief RegionStatus stream formatter

--- a/src/core/trackableobject_decl.hpp
+++ b/src/core/trackableobject_decl.hpp
@@ -36,13 +36,14 @@ namespace nanos {
       public:
          typedef std::list< DependableObject *> DependableObjectList; /**< Type list of DependableObject */
       private:
-         DependableObject      *_lastWriter; /**< Points to the last DependableObject registered as writer of the TrackableObject */
-         DependableObjectList   _versionReaders; /**< List of readers of the last version of the object */
-         Lock                   _readersLock; /**< Lock to provide exclusive access to the readers list */
-         Lock                   _writerLock; /**< Lock internally the object for secure access to _lastWriter */
-         CommutationDO         *_commDO; /**< Will be successor of all commutation tasks using this object untill a new reader/writer appears */
-         bool                   _hold; /**< Cannot be erased since it is in use */
-         uint64_t               _data_size; /**< Quantity of data associated with this trackable object */
+         DependableObject        *_lastWriter; /**< Points to the last DependableObject registered as writer of the TrackableObject */
+         DependableObjectList     _versionReaders; /**< List of readers of the last version of the object */
+         Lock                     _readersLock; /**< Lock to provide exclusive access to the readers list */
+         Lock                     _writerLock; /**< Lock internally the object for secure access to _lastWriter */
+         CommutationDO           *_commDO; /**< Will be successor of all commutation tasks using this object untill a new reader/writer appears */
+         bool                     _hold; /**< Cannot be erased since it is in use */
+         std::pair<void*, void*>  _data_range; /**< Range of data associated with this trackable object */
+
       public:
 
         /*! \brief TrackableObject default constructor
@@ -50,14 +51,14 @@ namespace nanos {
          *  Creates a TrackableObject with the given address associated.
          */
          TrackableObject ()
-            : _lastWriter ( NULL ), _versionReaders(), _readersLock(), _writerLock(), _commDO(NULL), _hold(false), _data_size(0) {}
+            : _lastWriter ( NULL ), _versionReaders(), _readersLock(), _writerLock(), _commDO(NULL), _hold(false), _data_range(std::pair<void*, void*>(NULL, NULL)) {}
 
         /*! \brief TrackableObject copy constructor
          *
          *  \param obj another TrackableObject
          */
          TrackableObject ( const TrackableObject &obj ) 
-            :   _lastWriter ( obj._lastWriter ), _versionReaders(), _readersLock(), _writerLock(), _commDO(NULL), _hold(false), _data_size(0) {}
+            :   _lastWriter ( obj._lastWriter ), _versionReaders(), _readersLock(), _writerLock(), _commDO(NULL), _hold(false), _data_range(std::pair<void*, void*>(NULL, NULL)) {}
 
         /*! \brief TrackableObject destructor
          */
@@ -149,8 +150,13 @@ namespace nanos {
          */
          bool isEmpty ( );
          
-         uint64_t getDataSize() const {return _data_size;}
-         void setDataSize(uint64_t data_size) {_data_size = data_size;}
+        /*! \brief Returns the range of data associated with this trackable object
+         */
+         std::pair<void*, void*> getDataRange() const;
+         
+        /*! \brief Returns the range of data associated with this trackable object
+         */
+         void setDataRange(std::pair<void*, void*> const range);
    };
 
    //! \brief RegionStatus stream formatter

--- a/src/core/trackableobject_decl.hpp
+++ b/src/core/trackableobject_decl.hpp
@@ -42,6 +42,7 @@ namespace nanos {
          Lock                   _writerLock; /**< Lock internally the object for secure access to _lastWriter */
          CommutationDO         *_commDO; /**< Will be successor of all commutation tasks using this object untill a new reader/writer appears */
          bool                   _hold; /**< Cannot be erased since it is in use */
+         uint64_t               _data_size; /**< Quantity of data associated with this trackable object */
       public:
 
         /*! \brief TrackableObject default constructor
@@ -49,14 +50,14 @@ namespace nanos {
          *  Creates a TrackableObject with the given address associated.
          */
          TrackableObject ()
-            : _lastWriter ( NULL ), _versionReaders(), _readersLock(), _writerLock(), _commDO(NULL), _hold(false) {}
+            : _lastWriter ( NULL ), _versionReaders(), _readersLock(), _writerLock(), _commDO(NULL), _hold(false), _data_size(0) {}
 
         /*! \brief TrackableObject copy constructor
          *
          *  \param obj another TrackableObject
          */
          TrackableObject ( const TrackableObject &obj ) 
-            :   _lastWriter ( obj._lastWriter ), _versionReaders(), _readersLock(), _writerLock(), _commDO(NULL), _hold(false) {}
+            :   _lastWriter ( obj._lastWriter ), _versionReaders(), _readersLock(), _writerLock(), _commDO(NULL), _hold(false), _data_size(0) {}
 
         /*! \brief TrackableObject destructor
          */
@@ -147,6 +148,9 @@ namespace nanos {
         /*! \brief Returns if the region has no information
          */
          bool isEmpty ( );
+         
+         uint64_t getDataSize() const {return _data_size;}
+         void setDataSize(uint64_t data_size) {_data_size = data_size;}
    };
 
    //! \brief RegionStatus stream formatter

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -793,7 +793,7 @@ endif
 #### Instrumentation #################################################################################
 ######################################################################################################
 tg_dump_cppflags=-I/home/ac/cluster/install/papi-6.0.0/include
-tg_dump_ldflags=-L/home/ac/cluster/install/papi-6.0.0/lib
+tg_dump_ldflags=-L/home/ac/cluster/install/papi-6.0.0/lib -lpapi
 
 if instrumentation_EXTRAE
 extrae_cppflags=-I@EXTRAE_INC@

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -792,6 +792,9 @@ endif
 ######################################################################################################
 #### Instrumentation #################################################################################
 ######################################################################################################
+tg_dump_cppflags=-I/home/ac/cluster/install/papi-6.0.0/include
+tg_dump_ldflags=-L/home/ac/cluster/install/papi-6.0.0/lib
+
 if instrumentation_EXTRAE
 extrae_cppflags=-I@EXTRAE_INC@
 extrae_ldflags=-L@EXTRAE_LIB@ -lnanostrace
@@ -936,9 +939,9 @@ instrumentation_libnanox_instrumentation_tdg_la_CXXFLAGS=$(common_instrumentatio
 instrumentation_libnanox_instrumentation_tdg_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags)
 instrumentation_libnanox_instrumentation_tdg_la_SOURCES=$(tdg_sources)
 
-instrumentation_libnanox_instrumentation_tg_dump_la_CPPFLAGS=$(common_instrumentation_CPPFLAGS)
+instrumentation_libnanox_instrumentation_tg_dump_la_CPPFLAGS=$(common_instrumentation_CPPFLAGS) $(tg_dump_cppflags)
 instrumentation_libnanox_instrumentation_tg_dump_la_CXXFLAGS=$(common_instrumentation_CXXFLAGS)
-instrumentation_libnanox_instrumentation_tg_dump_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags)
+instrumentation_libnanox_instrumentation_tg_dump_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags) $(tg_dump_ldflags)
 instrumentation_libnanox_instrumentation_tg_dump_la_SOURCES=$(tg_dump_sources)
 
 if instrumentation_EXTRAE
@@ -1003,9 +1006,9 @@ instrumentation_debug_libnanox_instrumentation_tdg_la_CXXFLAGS=$(common_instrume
 instrumentation_debug_libnanox_instrumentation_tdg_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags)
 instrumentation_debug_libnanox_instrumentation_tdg_la_SOURCES=$(tdg_sources)
 
-instrumentation_debug_libnanox_instrumentation_tg_dump_la_CPPFLAGS=$(common_instrumentation_debug_CPPFLAGS)
+instrumentation_debug_libnanox_instrumentation_tg_dump_la_CPPFLAGS=$(common_instrumentation_debug_CPPFLAGS) $(tg_dump_cppflags)
 instrumentation_debug_libnanox_instrumentation_tg_dump_la_CXXFLAGS=$(common_instrumentation_debug_CXXFLAGS)
-instrumentation_debug_libnanox_instrumentation_tg_dump_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags)
+instrumentation_debug_libnanox_instrumentation_tg_dump_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags) $(tg_dump_ldflags)
 instrumentation_debug_libnanox_instrumentation_tg_dump_la_SOURCES=$(tg_dump_sources)
 
 if instrumentation_EXTRAE

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -792,8 +792,10 @@ endif
 ######################################################################################################
 #### Instrumentation #################################################################################
 ######################################################################################################
-tg_dump_cppflags=-I/home/ac/cluster/install/papi-6.0.0/include
-tg_dump_ldflags=-L/home/ac/cluster/install/papi-6.0.0/lib -lpapi
+if instrumentation_TGDUMP
+tg_dump_cppflags=-I@PAPI_INC@
+tg_dump_ldflags=-L@PAPI_LIB@ -lpapi
+endif
 
 if instrumentation_EXTRAE
 extrae_cppflags=-I@EXTRAE_INC@
@@ -857,7 +859,6 @@ debug_LTLIBRARIES += \
 	debug/libnanox-instrumentation-empty_trace.la \
 	debug/libnanox-instrumentation-print_trace.la \
 	debug/libnanox-instrumentation-tdg.la \
-	debug/libnanox-instrumentation-tg-dump.la \
 	$(END)
 
 if instrumentation_EXTRAE
@@ -866,6 +867,10 @@ endif
 
 if instrumentation_AYUDAME
 debug_LTLIBRARIES+=debug/libnanox-instrumentation-ayudame.la
+endif
+
+if instrumentation_TGDUMP
+debug_LTLIBRARIES+=debug/libnanox-instrumentation-tg-dump.la
 endif
 
 debug_libnanox_instrumentation_empty_trace_la_CPPFLAGS=$(common_debug_CPPFLAGS)
@@ -883,10 +888,12 @@ debug_libnanox_instrumentation_tdg_la_CXXFLAGS=$(common_debug_CXXFLAGS)
 debug_libnanox_instrumentation_tdg_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags)
 debug_libnanox_instrumentation_tdg_la_SOURCES=$(tdg_sources)
 
+if instrumentation_TGDUMP
 debug_libnanox_instrumentation_tg_dump_la_CPPFLAGS=$(common_debug_CPPFLAGS) $(tg_dump_cppflags)
 debug_libnanox_instrumentation_tg_dump_la_CXXFLAGS=$(common_debug_CXXFLAGS)
 debug_libnanox_instrumentation_tg_dump_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags) $(tg_dump_ldflags)
 debug_libnanox_instrumentation_tg_dump_la_SOURCES=$(tg_dump_sources)
+endif
 
 if instrumentation_EXTRAE
 debug_libnanox_instrumentation_extrae_la_CPPFLAGS=$(common_debug_CPPFLAGS)
@@ -908,7 +915,6 @@ instrumentation_LTLIBRARIES += \
 	instrumentation/libnanox-instrumentation-empty_trace.la \
 	instrumentation/libnanox-instrumentation-print_trace.la \
 	instrumentation/libnanox-instrumentation-tdg.la \
-	instrumentation/libnanox-instrumentation-tg-dump.la \
 	instrumentation/libnanox-instrumentation-ompt.la \
 	$(END)
 
@@ -922,6 +928,10 @@ endif
 
 if instrumentation_NEXTSIM
 instrumentation_LTLIBRARIES+=instrumentation/libnanox-instrumentation-nextsim.la
+endif
+
+if instrumentation_TGDUMP
+instrumentation_LTLIBRARIES+=instrumentation/libnanox-instrumentation-tg-dump.la
 endif
 
 instrumentation_libnanox_instrumentation_empty_trace_la_CPPFLAGS=$(common_instrumentation_CPPFLAGS)
@@ -939,10 +949,12 @@ instrumentation_libnanox_instrumentation_tdg_la_CXXFLAGS=$(common_instrumentatio
 instrumentation_libnanox_instrumentation_tdg_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags)
 instrumentation_libnanox_instrumentation_tdg_la_SOURCES=$(tdg_sources)
 
+if instrumentation_TGDUMP
 instrumentation_libnanox_instrumentation_tg_dump_la_CPPFLAGS=$(common_instrumentation_CPPFLAGS) $(tg_dump_cppflags)
 instrumentation_libnanox_instrumentation_tg_dump_la_CXXFLAGS=$(common_instrumentation_CXXFLAGS)
 instrumentation_libnanox_instrumentation_tg_dump_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags) $(tg_dump_ldflags)
 instrumentation_libnanox_instrumentation_tg_dump_la_SOURCES=$(tg_dump_sources)
+endif
 
 if instrumentation_EXTRAE
 instrumentation_libnanox_instrumentation_extrae_la_CPPFLAGS=$(common_instrumentation_CPPFLAGS) $(extrae_cppflags)
@@ -979,7 +991,6 @@ instrumentation_debug_LTLIBRARIES += \
 	instrumentation-debug/libnanox-instrumentation-empty_trace.la \
 	instrumentation-debug/libnanox-instrumentation-print_trace.la \
 	instrumentation-debug/libnanox-instrumentation-tdg.la \
-	instrumentation-debug/libnanox-instrumentation-tg-dump.la \
 	instrumentation-debug/libnanox-instrumentation-ompt.la \
 	$(END)
 
@@ -989,6 +1000,10 @@ endif
 
 if instrumentation_AYUDAME
 instrumentation_debug_LTLIBRARIES+=instrumentation-debug/libnanox-instrumentation-ayudame.la
+endif
+
+if instrumentation_TGDUMP
+instrumentation_debug_LTLIBRARIES+=instrumentation-debug/libnanox-instrumentation-tg-dump.la
 endif
 
 instrumentation_debug_libnanox_instrumentation_empty_trace_la_CPPFLAGS=$(common_instrumentation_debug_CPPFLAGS)
@@ -1006,10 +1021,12 @@ instrumentation_debug_libnanox_instrumentation_tdg_la_CXXFLAGS=$(common_instrume
 instrumentation_debug_libnanox_instrumentation_tdg_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags)
 instrumentation_debug_libnanox_instrumentation_tdg_la_SOURCES=$(tdg_sources)
 
+if instrumentation_TGDUMP
 instrumentation_debug_libnanox_instrumentation_tg_dump_la_CPPFLAGS=$(common_instrumentation_debug_CPPFLAGS) $(tg_dump_cppflags)
 instrumentation_debug_libnanox_instrumentation_tg_dump_la_CXXFLAGS=$(common_instrumentation_debug_CXXFLAGS)
 instrumentation_debug_libnanox_instrumentation_tg_dump_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags) $(tg_dump_ldflags)
 instrumentation_debug_libnanox_instrumentation_tg_dump_la_SOURCES=$(tg_dump_sources)
+endif
 
 if instrumentation_EXTRAE
 instrumentation_debug_libnanox_instrumentation_extrae_la_CPPFLAGS=$(common_instrumentation_debug_CPPFLAGS) $(extrae_cppflags)
@@ -1037,7 +1054,6 @@ performance_LTLIBRARIES += \
 	performance/libnanox-instrumentation-empty_trace.la \
 	performance/libnanox-instrumentation-print_trace.la \
 	performance/libnanox-instrumentation-tdg.la \
-	performance/libnanox-instrumentation-tg-dump.la \
 	$(END)
 
 if instrumentation_EXTRAE
@@ -1046,6 +1062,10 @@ endif
 
 if instrumentation_AYUDAME
 performance_LTLIBRARIES+=performance/libnanox-instrumentation-ayudame.la
+endif
+
+if instrumentation_TGDUMP
+performance_LTLIBRARIES+=performance/libnanox-instrumentation-tg-dump.la
 endif
 
 performance_libnanox_instrumentation_empty_trace_la_CPPFLAGS=$(common_performance_CPPFLAGS)
@@ -1063,10 +1083,12 @@ performance_libnanox_instrumentation_tdg_la_CXXFLAGS=$(common_performance_CXXFLA
 performance_libnanox_instrumentation_tdg_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags)
 performance_libnanox_instrumentation_tdg_la_SOURCES=$(tdg_sources)
 
+if instrumentation_TGDUMP
 performance_libnanox_instrumentation_tg_dump_la_CPPFLAGS=$(common_performance_CPPFLAGS) $(tg_dump_cppflags)
 performance_libnanox_instrumentation_tg_dump_la_CXXFLAGS=$(common_performance_CXXFLAGS)
 performance_libnanox_instrumentation_tg_dump_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags) $(tg_dump_ldflags)
 performance_libnanox_instrumentation_tg_dump_la_SOURCES=$(tg_dump_sources)
+endif
 
 if instrumentation_EXTRAE
 performance_libnanox_instrumentation_extrae_la_CPPFLAGS=$(common_performance_CPPFLAGS)

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -831,6 +831,11 @@ tdg_sources=\
     instrumentation/tdg_utils.hpp \
     instrumentation/tdg.cpp \
     $(END)
+	 
+tg_dump_sources=\
+   instrumentation/tg_dump_utils.hpp \
+   instrumentation/tg_dump.cpp \
+   $(END)
 
 ompt_sources=\
     instrumentation/ompt.cpp \
@@ -849,6 +854,7 @@ debug_LTLIBRARIES += \
 	debug/libnanox-instrumentation-empty_trace.la \
 	debug/libnanox-instrumentation-print_trace.la \
 	debug/libnanox-instrumentation-tdg.la \
+	debug/libnanox-instrumentation-tg-dump.la \
 	$(END)
 
 if instrumentation_EXTRAE
@@ -874,6 +880,11 @@ debug_libnanox_instrumentation_tdg_la_CXXFLAGS=$(common_debug_CXXFLAGS)
 debug_libnanox_instrumentation_tdg_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags)
 debug_libnanox_instrumentation_tdg_la_SOURCES=$(tdg_sources)
 
+debug_libnanox_instrumentation_tg_dump_la_CPPFLAGS=$(common_debug_CPPFLAGS)
+debug_libnanox_instrumentation_tg_dump_la_CXXFLAGS=$(common_debug_CXXFLAGS)
+debug_libnanox_instrumentation_tg_dump_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags)
+debug_libnanox_instrumentation_tg_dump_la_SOURCES=$(tg_dump_sources)
+
 if instrumentation_EXTRAE
 debug_libnanox_instrumentation_extrae_la_CPPFLAGS=$(common_debug_CPPFLAGS)
 debug_libnanox_instrumentation_extrae_la_CXXFLAGS=$(common_debug_CXXFLAGS)
@@ -894,6 +905,7 @@ instrumentation_LTLIBRARIES += \
 	instrumentation/libnanox-instrumentation-empty_trace.la \
 	instrumentation/libnanox-instrumentation-print_trace.la \
 	instrumentation/libnanox-instrumentation-tdg.la \
+	instrumentation/libnanox-instrumentation-tg-dump.la \
 	instrumentation/libnanox-instrumentation-ompt.la \
 	$(END)
 
@@ -923,6 +935,11 @@ instrumentation_libnanox_instrumentation_tdg_la_CPPFLAGS=$(common_instrumentatio
 instrumentation_libnanox_instrumentation_tdg_la_CXXFLAGS=$(common_instrumentation_CXXFLAGS)
 instrumentation_libnanox_instrumentation_tdg_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags)
 instrumentation_libnanox_instrumentation_tdg_la_SOURCES=$(tdg_sources)
+
+instrumentation_libnanox_instrumentation_tg_dump_la_CPPFLAGS=$(common_instrumentation_CPPFLAGS)
+instrumentation_libnanox_instrumentation_tg_dump_la_CXXFLAGS=$(common_instrumentation_CXXFLAGS)
+instrumentation_libnanox_instrumentation_tg_dump_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags)
+instrumentation_libnanox_instrumentation_tg_dump_la_SOURCES=$(tg_dump_sources)
 
 if instrumentation_EXTRAE
 instrumentation_libnanox_instrumentation_extrae_la_CPPFLAGS=$(common_instrumentation_CPPFLAGS) $(extrae_cppflags)
@@ -959,6 +976,7 @@ instrumentation_debug_LTLIBRARIES += \
 	instrumentation-debug/libnanox-instrumentation-empty_trace.la \
 	instrumentation-debug/libnanox-instrumentation-print_trace.la \
 	instrumentation-debug/libnanox-instrumentation-tdg.la \
+	instrumentation-debug/libnanox-instrumentation-tg-dump.la \
 	instrumentation-debug/libnanox-instrumentation-ompt.la \
 	$(END)
 
@@ -984,6 +1002,11 @@ instrumentation_debug_libnanox_instrumentation_tdg_la_CPPFLAGS=$(common_instrume
 instrumentation_debug_libnanox_instrumentation_tdg_la_CXXFLAGS=$(common_instrumentation_debug_CXXFLAGS)
 instrumentation_debug_libnanox_instrumentation_tdg_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags)
 instrumentation_debug_libnanox_instrumentation_tdg_la_SOURCES=$(tdg_sources)
+
+instrumentation_debug_libnanox_instrumentation_tg_dump_la_CPPFLAGS=$(common_instrumentation_debug_CPPFLAGS)
+instrumentation_debug_libnanox_instrumentation_tg_dump_la_CXXFLAGS=$(common_instrumentation_debug_CXXFLAGS)
+instrumentation_debug_libnanox_instrumentation_tg_dump_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags)
+instrumentation_debug_libnanox_instrumentation_tg_dump_la_SOURCES=$(tg_dump_sources)
 
 if instrumentation_EXTRAE
 instrumentation_debug_libnanox_instrumentation_extrae_la_CPPFLAGS=$(common_instrumentation_debug_CPPFLAGS) $(extrae_cppflags)
@@ -1011,6 +1034,7 @@ performance_LTLIBRARIES += \
 	performance/libnanox-instrumentation-empty_trace.la \
 	performance/libnanox-instrumentation-print_trace.la \
 	performance/libnanox-instrumentation-tdg.la \
+	performance/libnanox-instrumentation-tg-dump.la \
 	$(END)
 
 if instrumentation_EXTRAE
@@ -1035,6 +1059,11 @@ performance_libnanox_instrumentation_tdg_la_CPPFLAGS=$(common_performance_CPPFLA
 performance_libnanox_instrumentation_tdg_la_CXXFLAGS=$(common_performance_CXXFLAGS)
 performance_libnanox_instrumentation_tdg_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags)
 performance_libnanox_instrumentation_tdg_la_SOURCES=$(tdg_sources)
+
+performance_libnanox_instrumentation_tg_dump_la_CPPFLAGS=$(common_performance_CPPFLAGS)
+performance_libnanox_instrumentation_tg_dump_la_CXXFLAGS=$(common_performance_CXXFLAGS)
+performance_libnanox_instrumentation_tg_dump_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags)
+performance_libnanox_instrumentation_tg_dump_la_SOURCES=$(tg_dump_sources)
 
 if instrumentation_EXTRAE
 performance_libnanox_instrumentation_extrae_la_CPPFLAGS=$(common_performance_CPPFLAGS)

--- a/src/plugins/Makefile.am
+++ b/src/plugins/Makefile.am
@@ -883,9 +883,9 @@ debug_libnanox_instrumentation_tdg_la_CXXFLAGS=$(common_debug_CXXFLAGS)
 debug_libnanox_instrumentation_tdg_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags)
 debug_libnanox_instrumentation_tdg_la_SOURCES=$(tdg_sources)
 
-debug_libnanox_instrumentation_tg_dump_la_CPPFLAGS=$(common_debug_CPPFLAGS)
+debug_libnanox_instrumentation_tg_dump_la_CPPFLAGS=$(common_debug_CPPFLAGS) $(tg_dump_cppflags)
 debug_libnanox_instrumentation_tg_dump_la_CXXFLAGS=$(common_debug_CXXFLAGS)
-debug_libnanox_instrumentation_tg_dump_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags)
+debug_libnanox_instrumentation_tg_dump_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags) $(tg_dump_ldflags)
 debug_libnanox_instrumentation_tg_dump_la_SOURCES=$(tg_dump_sources)
 
 if instrumentation_EXTRAE
@@ -1063,9 +1063,9 @@ performance_libnanox_instrumentation_tdg_la_CXXFLAGS=$(common_performance_CXXFLA
 performance_libnanox_instrumentation_tdg_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags)
 performance_libnanox_instrumentation_tdg_la_SOURCES=$(tdg_sources)
 
-performance_libnanox_instrumentation_tg_dump_la_CPPFLAGS=$(common_performance_CPPFLAGS)
+performance_libnanox_instrumentation_tg_dump_la_CPPFLAGS=$(common_performance_CPPFLAGS) $(tg_dump_cppflags)
 performance_libnanox_instrumentation_tg_dump_la_CXXFLAGS=$(common_performance_CXXFLAGS)
-performance_libnanox_instrumentation_tg_dump_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags)
+performance_libnanox_instrumentation_tg_dump_la_LDFLAGS=$(AM_LDFLAGS) $(ld_plugin_flags) $(tg_dump_ldflags)
 performance_libnanox_instrumentation_tg_dump_la_SOURCES=$(tg_dump_sources)
 
 if instrumentation_EXTRAE

--- a/src/plugins/deps/basedependenciesdomain.hpp
+++ b/src/plugins/deps/basedependenciesdomain.hpp
@@ -65,7 +65,7 @@ inline void BaseDependenciesDomain::dependOnLastWriter ( DependableObject &depOb
          NANOS_INSTRUMENT ( int id_sender = wd_sender ? wd_sender->getId() : lastWriter->getId(); )
          NANOS_INSTRUMENT ( int id_receiver = wd_receiver ? wd_receiver->getId() : depObj.getId(); )
 
-         NANOS_INSTRUMENT ( nanos_event_value_t Values[3]; )
+         NANOS_INSTRUMENT ( nanos_event_value_t Values[4]; )
          NANOS_INSTRUMENT ( Values[0] = ( ((nanos_event_value_t) id_sender) << 32 ) + id_receiver; )
 
          NANOS_INSTRUMENT ( if ( wd_sender && wd_receiver ) { )
@@ -100,7 +100,8 @@ inline void BaseDependenciesDomain::dependOnLastWriter ( DependableObject &depOb
          NANOS_INSTRUMENT ( })
 
          NANOS_INSTRUMENT ( Values[2] = ((nanos_event_value_t) target.getAddress() ); )
-         NANOS_INSTRUMENT ( sys.getInstrumentation()->raisePointEvents(3, _insKeyDeps, Values); )
+         NANOS_INSTRUMENT ( Values[3] = ((nanos_event_value_t) status.getDataSize()); )
+         NANOS_INSTRUMENT ( sys.getInstrumentation()->raisePointEvents(4, _insKeyDeps, Values); )
 
          if ( lastWriter->addSuccessor( depObj ) ) {
             // new dependence lastWriter -> depObj
@@ -130,7 +131,7 @@ inline void BaseDependenciesDomain::dependOnReaders( DependableObject &depObj, T
       NANOS_INSTRUMENT ( int id_sender = wd_sender ? wd_sender->getId() : predecessorReader->getId(); )
       NANOS_INSTRUMENT ( int id_receiver = wd_receiver ? wd_receiver->getId() : depObj.getId(); )
 
-      NANOS_INSTRUMENT ( nanos_event_value_t Values[3]; )
+      NANOS_INSTRUMENT ( nanos_event_value_t Values[4]; )
       NANOS_INSTRUMENT ( Values[0] = ( ((nanos_event_value_t) id_sender) << 32 ) + id_receiver; )
 
       NANOS_INSTRUMENT ( if ( wd_sender && wd_receiver ) { )
@@ -160,7 +161,8 @@ inline void BaseDependenciesDomain::dependOnReaders( DependableObject &depObj, T
       NANOS_INSTRUMENT ( } )
 
       NANOS_INSTRUMENT ( Values[2] = ((nanos_event_value_t) target.getAddress() ); )
-      NANOS_INSTRUMENT ( sys.getInstrumentation()->raisePointEvents(3, _insKeyDeps, Values); )
+      NANOS_INSTRUMENT ( Values[3] = ((nanos_event_value_t) 2); )
+      NANOS_INSTRUMENT ( sys.getInstrumentation()->raisePointEvents(4, _insKeyDeps, Values); )
 
       if ( predecessorReader->addSuccessor( depObj ) ) {
          // new dependence predecessorReader -> depObj
@@ -277,7 +279,7 @@ inline void BaseDependenciesDomain::submitDependableObjectCommutativeDataAccess 
    // Concurrent new instrument event: dependence depObj -> commDO
    NANOS_INSTRUMENT ( WorkDescriptor *wd_sender = (WorkDescriptor *) depObj.getRelatedObject(); )
    NANOS_INSTRUMENT ( if ( wd_sender && commDO ) { )
-      NANOS_INSTRUMENT ( nanos_event_value_t Values[3]; )
+      NANOS_INSTRUMENT ( nanos_event_value_t Values[4]; )
       NANOS_INSTRUMENT ( Values[0] = ( ((nanos_event_value_t) wd_sender->getId()) << 32 ) + commDO->getId(); )
       NANOS_INSTRUMENT ( if ( accessType.concurrent ) { );
          NANOS_INSTRUMENT ( Values[1] = ((nanos_event_value_t) 4); )
@@ -287,7 +289,8 @@ inline void BaseDependenciesDomain::submitDependableObjectCommutativeDataAccess 
          NANOS_INSTRUMENT ( Values[1] = ((nanos_event_value_t) 8); )
       NANOS_INSTRUMENT ( })
       NANOS_INSTRUMENT ( Values[2] = ((nanos_event_value_t) target.getAddress() ); )
-      NANOS_INSTRUMENT ( sys.getInstrumentation()->raisePointEvents(3, _insKeyDeps, Values); )
+      NANOS_INSTRUMENT ( Values[3] = ((nanos_event_value_t) 3); )
+      NANOS_INSTRUMENT ( sys.getInstrumentation()->raisePointEvents(4, _insKeyDeps, Values); )
    NANOS_INSTRUMENT ( } )
 
    // Add the Commutation object as successor of the current DO (depObj)

--- a/src/plugins/deps/basedependenciesdomain.hpp
+++ b/src/plugins/deps/basedependenciesdomain.hpp
@@ -161,7 +161,7 @@ inline void BaseDependenciesDomain::dependOnReaders( DependableObject &depObj, T
       NANOS_INSTRUMENT ( } )
 
       NANOS_INSTRUMENT ( Values[2] = ((nanos_event_value_t) target.getAddress() ); )
-      NANOS_INSTRUMENT ( Values[3] = ((nanos_event_value_t) 2); )
+      NANOS_INSTRUMENT ( Values[3] = ((nanos_event_value_t) status.getDataSize() ); )
       NANOS_INSTRUMENT ( sys.getInstrumentation()->raisePointEvents(4, _insKeyDeps, Values); )
 
       if ( predecessorReader->addSuccessor( depObj ) ) {
@@ -289,7 +289,7 @@ inline void BaseDependenciesDomain::submitDependableObjectCommutativeDataAccess 
          NANOS_INSTRUMENT ( Values[1] = ((nanos_event_value_t) 8); )
       NANOS_INSTRUMENT ( })
       NANOS_INSTRUMENT ( Values[2] = ((nanos_event_value_t) target.getAddress() ); )
-      NANOS_INSTRUMENT ( Values[3] = ((nanos_event_value_t) 3); )
+      NANOS_INSTRUMENT ( Values[3] = ((nanos_event_value_t) status.getDataSize() ); )
       NANOS_INSTRUMENT ( sys.getInstrumentation()->raisePointEvents(4, _insKeyDeps, Values); )
    NANOS_INSTRUMENT ( } )
 
@@ -361,4 +361,3 @@ inline void BaseDependenciesDomain::submitDependableObjectInputNoReadDataAccess 
 } // namespace nanos
 
 #endif
-

--- a/src/plugins/deps/basedependenciesdomain.hpp
+++ b/src/plugins/deps/basedependenciesdomain.hpp
@@ -100,8 +100,8 @@ inline void BaseDependenciesDomain::dependOnLastWriter ( DependableObject &depOb
          NANOS_INSTRUMENT ( })
 
          NANOS_INSTRUMENT ( Values[2] = ((nanos_event_value_t) target.getAddress() ); )
-         NANOS_INSTRUMENT ( Values[3] = ((nanos_event_value_t) status.getDataRange().first); )
-         NANOS_INSTRUMENT ( Values[4] = ((nanos_event_value_t) status.getDataRange().second); )
+         NANOS_INSTRUMENT ( Values[3] = ((nanos_event_value_t) status.getOverlapRange().first); )
+         NANOS_INSTRUMENT ( Values[4] = ((nanos_event_value_t) status.getOverlapRange().second); )
          NANOS_INSTRUMENT ( sys.getInstrumentation()->raisePointEvents(5, _insKeyDeps, Values); )
 
          if ( lastWriter->addSuccessor( depObj ) ) {
@@ -162,8 +162,8 @@ inline void BaseDependenciesDomain::dependOnReaders( DependableObject &depObj, T
       NANOS_INSTRUMENT ( } )
 
       NANOS_INSTRUMENT ( Values[2] = ((nanos_event_value_t) target.getAddress() ); )
-      NANOS_INSTRUMENT ( Values[3] = ((nanos_event_value_t) status.getDataRange().first); )
-      NANOS_INSTRUMENT ( Values[4] = ((nanos_event_value_t) status.getDataRange().second); )
+      NANOS_INSTRUMENT ( Values[3] = ((nanos_event_value_t) status.getOverlapRange().first); )
+      NANOS_INSTRUMENT ( Values[4] = ((nanos_event_value_t) status.getOverlapRange().second); )
       NANOS_INSTRUMENT ( sys.getInstrumentation()->raisePointEvents(5, _insKeyDeps, Values); )
 
       if ( predecessorReader->addSuccessor( depObj ) ) {
@@ -291,8 +291,8 @@ inline void BaseDependenciesDomain::submitDependableObjectCommutativeDataAccess 
          NANOS_INSTRUMENT ( Values[1] = ((nanos_event_value_t) 8); )
       NANOS_INSTRUMENT ( })
       NANOS_INSTRUMENT ( Values[2] = ((nanos_event_value_t) target.getAddress() ); )
-      NANOS_INSTRUMENT ( Values[3] = ((nanos_event_value_t) status.getDataRange().first); )
-      NANOS_INSTRUMENT ( Values[4] = ((nanos_event_value_t) status.getDataRange().second); )
+      NANOS_INSTRUMENT ( Values[3] = ((nanos_event_value_t) status.getOverlapRange().first); )
+      NANOS_INSTRUMENT ( Values[4] = ((nanos_event_value_t) status.getOverlapRange().second); )
       NANOS_INSTRUMENT ( sys.getInstrumentation()->raisePointEvents(5, _insKeyDeps, Values); )
    NANOS_INSTRUMENT ( } )
 

--- a/src/plugins/deps/basedependenciesdomain.hpp
+++ b/src/plugins/deps/basedependenciesdomain.hpp
@@ -65,7 +65,7 @@ inline void BaseDependenciesDomain::dependOnLastWriter ( DependableObject &depOb
          NANOS_INSTRUMENT ( int id_sender = wd_sender ? wd_sender->getId() : lastWriter->getId(); )
          NANOS_INSTRUMENT ( int id_receiver = wd_receiver ? wd_receiver->getId() : depObj.getId(); )
 
-         NANOS_INSTRUMENT ( nanos_event_value_t Values[4]; )
+         NANOS_INSTRUMENT ( nanos_event_value_t Values[5]; )
          NANOS_INSTRUMENT ( Values[0] = ( ((nanos_event_value_t) id_sender) << 32 ) + id_receiver; )
 
          NANOS_INSTRUMENT ( if ( wd_sender && wd_receiver ) { )
@@ -100,8 +100,9 @@ inline void BaseDependenciesDomain::dependOnLastWriter ( DependableObject &depOb
          NANOS_INSTRUMENT ( })
 
          NANOS_INSTRUMENT ( Values[2] = ((nanos_event_value_t) target.getAddress() ); )
-         NANOS_INSTRUMENT ( Values[3] = ((nanos_event_value_t) status.getDataSize()); )
-         NANOS_INSTRUMENT ( sys.getInstrumentation()->raisePointEvents(4, _insKeyDeps, Values); )
+         NANOS_INSTRUMENT ( Values[3] = ((nanos_event_value_t) status.getDataRange().first); )
+         NANOS_INSTRUMENT ( Values[4] = ((nanos_event_value_t) status.getDataRange().second); )
+         NANOS_INSTRUMENT ( sys.getInstrumentation()->raisePointEvents(5, _insKeyDeps, Values); )
 
          if ( lastWriter->addSuccessor( depObj ) ) {
             // new dependence lastWriter -> depObj
@@ -131,7 +132,7 @@ inline void BaseDependenciesDomain::dependOnReaders( DependableObject &depObj, T
       NANOS_INSTRUMENT ( int id_sender = wd_sender ? wd_sender->getId() : predecessorReader->getId(); )
       NANOS_INSTRUMENT ( int id_receiver = wd_receiver ? wd_receiver->getId() : depObj.getId(); )
 
-      NANOS_INSTRUMENT ( nanos_event_value_t Values[4]; )
+      NANOS_INSTRUMENT ( nanos_event_value_t Values[5]; )
       NANOS_INSTRUMENT ( Values[0] = ( ((nanos_event_value_t) id_sender) << 32 ) + id_receiver; )
 
       NANOS_INSTRUMENT ( if ( wd_sender && wd_receiver ) { )
@@ -161,8 +162,9 @@ inline void BaseDependenciesDomain::dependOnReaders( DependableObject &depObj, T
       NANOS_INSTRUMENT ( } )
 
       NANOS_INSTRUMENT ( Values[2] = ((nanos_event_value_t) target.getAddress() ); )
-      NANOS_INSTRUMENT ( Values[3] = ((nanos_event_value_t) status.getDataSize() ); )
-      NANOS_INSTRUMENT ( sys.getInstrumentation()->raisePointEvents(4, _insKeyDeps, Values); )
+      NANOS_INSTRUMENT ( Values[3] = ((nanos_event_value_t) status.getDataRange().first); )
+      NANOS_INSTRUMENT ( Values[4] = ((nanos_event_value_t) status.getDataRange().second); )
+      NANOS_INSTRUMENT ( sys.getInstrumentation()->raisePointEvents(5, _insKeyDeps, Values); )
 
       if ( predecessorReader->addSuccessor( depObj ) ) {
          // new dependence predecessorReader -> depObj
@@ -279,7 +281,7 @@ inline void BaseDependenciesDomain::submitDependableObjectCommutativeDataAccess 
    // Concurrent new instrument event: dependence depObj -> commDO
    NANOS_INSTRUMENT ( WorkDescriptor *wd_sender = (WorkDescriptor *) depObj.getRelatedObject(); )
    NANOS_INSTRUMENT ( if ( wd_sender && commDO ) { )
-      NANOS_INSTRUMENT ( nanos_event_value_t Values[4]; )
+      NANOS_INSTRUMENT ( nanos_event_value_t Values[5]; )
       NANOS_INSTRUMENT ( Values[0] = ( ((nanos_event_value_t) wd_sender->getId()) << 32 ) + commDO->getId(); )
       NANOS_INSTRUMENT ( if ( accessType.concurrent ) { );
          NANOS_INSTRUMENT ( Values[1] = ((nanos_event_value_t) 4); )
@@ -289,8 +291,9 @@ inline void BaseDependenciesDomain::submitDependableObjectCommutativeDataAccess 
          NANOS_INSTRUMENT ( Values[1] = ((nanos_event_value_t) 8); )
       NANOS_INSTRUMENT ( })
       NANOS_INSTRUMENT ( Values[2] = ((nanos_event_value_t) target.getAddress() ); )
-      NANOS_INSTRUMENT ( Values[3] = ((nanos_event_value_t) status.getDataSize() ); )
-      NANOS_INSTRUMENT ( sys.getInstrumentation()->raisePointEvents(4, _insKeyDeps, Values); )
+      NANOS_INSTRUMENT ( Values[3] = ((nanos_event_value_t) status.getDataRange().first); )
+      NANOS_INSTRUMENT ( Values[4] = ((nanos_event_value_t) status.getDataRange().second); )
+      NANOS_INSTRUMENT ( sys.getInstrumentation()->raisePointEvents(5, _insKeyDeps, Values); )
    NANOS_INSTRUMENT ( } )
 
    // Add the Commutation object as successor of the current DO (depObj)

--- a/src/plugins/deps/basedependenciesdomain_decl.hpp
+++ b/src/plugins/deps/basedependenciesdomain_decl.hpp
@@ -43,7 +43,7 @@ namespace nanos {
           *  \param[in,out] status status of the base address
           */
          virtual CommutationDO *createCommutationDO(BaseDependency const &target, AccessType const &accessType, TrackableObject &status);
-         NANOS_INSTRUMENT ( nanos_event_key_t   _insKeyDeps[3]; ) /**< Instrumentation key dependences */
+         NANOS_INSTRUMENT ( nanos_event_key_t   _insKeyDeps[4]; ) /**< Instrumentation key dependences */
 
       protected:         
          /*! \brief Finalizes a reduction if active.
@@ -168,6 +168,7 @@ namespace nanos {
             NANOS_INSTRUMENT ( _insKeyDeps[0] = ID->getEventKey("dependence"); )
             NANOS_INSTRUMENT ( _insKeyDeps[1] = ID->getEventKey("dep-direction"); )
             NANOS_INSTRUMENT ( _insKeyDeps[2] = ID->getEventKey("dep-address"); )
+            NANOS_INSTRUMENT ( _insKeyDeps[3] = ID->getEventKey("dep-size"); )
          }
          
          BaseDependenciesDomain ( const BaseDependenciesDomain &depDomain ) : DependenciesDomain( depDomain ), _lastDepObjId ( depDomain._lastDepObjId ) {
@@ -175,6 +176,7 @@ namespace nanos {
             NANOS_INSTRUMENT ( _insKeyDeps[0] = ID->getEventKey("dependence"); )
             NANOS_INSTRUMENT ( _insKeyDeps[1] = ID->getEventKey("dep-direction"); )
             NANOS_INSTRUMENT ( _insKeyDeps[2] = ID->getEventKey("dep-address"); )
+            NANOS_INSTRUMENT ( _insKeyDeps[3] = ID->getEventKey("dep-size"); )
          }
    };
 

--- a/src/plugins/deps/basedependenciesdomain_decl.hpp
+++ b/src/plugins/deps/basedependenciesdomain_decl.hpp
@@ -43,7 +43,7 @@ namespace nanos {
           *  \param[in,out] status status of the base address
           */
          virtual CommutationDO *createCommutationDO(BaseDependency const &target, AccessType const &accessType, TrackableObject &status);
-         NANOS_INSTRUMENT ( nanos_event_key_t   _insKeyDeps[4]; ) /**< Instrumentation key dependences */
+         NANOS_INSTRUMENT ( nanos_event_key_t   _insKeyDeps[5]; ) /**< Instrumentation key dependences */
 
       protected:         
          /*! \brief Finalizes a reduction if active.
@@ -168,7 +168,8 @@ namespace nanos {
             NANOS_INSTRUMENT ( _insKeyDeps[0] = ID->getEventKey("dependence"); )
             NANOS_INSTRUMENT ( _insKeyDeps[1] = ID->getEventKey("dep-direction"); )
             NANOS_INSTRUMENT ( _insKeyDeps[2] = ID->getEventKey("dep-address"); )
-            NANOS_INSTRUMENT ( _insKeyDeps[3] = ID->getEventKey("dep-size"); )
+            NANOS_INSTRUMENT ( _insKeyDeps[3] = ID->getEventKey("dep-range-start"); )
+            NANOS_INSTRUMENT ( _insKeyDeps[4] = ID->getEventKey("dep-range-end" ); )
          }
          
          BaseDependenciesDomain ( const BaseDependenciesDomain &depDomain ) : DependenciesDomain( depDomain ), _lastDepObjId ( depDomain._lastDepObjId ) {
@@ -176,11 +177,11 @@ namespace nanos {
             NANOS_INSTRUMENT ( _insKeyDeps[0] = ID->getEventKey("dependence"); )
             NANOS_INSTRUMENT ( _insKeyDeps[1] = ID->getEventKey("dep-direction"); )
             NANOS_INSTRUMENT ( _insKeyDeps[2] = ID->getEventKey("dep-address"); )
-            NANOS_INSTRUMENT ( _insKeyDeps[3] = ID->getEventKey("dep-size"); )
+            NANOS_INSTRUMENT ( _insKeyDeps[3] = ID->getEventKey("dep-range-start"); )
+            NANOS_INSTRUMENT ( _insKeyDeps[4] = ID->getEventKey("dep-range-end" ); )
          }
    };
 
 } // namespace nanos
 
 #endif
-

--- a/src/plugins/deps/basedependenciesdomain_decl.hpp
+++ b/src/plugins/deps/basedependenciesdomain_decl.hpp
@@ -168,8 +168,8 @@ namespace nanos {
             NANOS_INSTRUMENT ( _insKeyDeps[0] = ID->getEventKey("dependence"); )
             NANOS_INSTRUMENT ( _insKeyDeps[1] = ID->getEventKey("dep-direction"); )
             NANOS_INSTRUMENT ( _insKeyDeps[2] = ID->getEventKey("dep-address"); )
-            NANOS_INSTRUMENT ( _insKeyDeps[3] = ID->getEventKey("dep-range-start"); )
-            NANOS_INSTRUMENT ( _insKeyDeps[4] = ID->getEventKey("dep-range-end" ); )
+            NANOS_INSTRUMENT ( _insKeyDeps[3] = ID->getEventKey("dep-overlap-start"); )
+            NANOS_INSTRUMENT ( _insKeyDeps[4] = ID->getEventKey("dep-overlap-end" ); )
          }
          
          BaseDependenciesDomain ( const BaseDependenciesDomain &depDomain ) : DependenciesDomain( depDomain ), _lastDepObjId ( depDomain._lastDepObjId ) {
@@ -177,8 +177,8 @@ namespace nanos {
             NANOS_INSTRUMENT ( _insKeyDeps[0] = ID->getEventKey("dependence"); )
             NANOS_INSTRUMENT ( _insKeyDeps[1] = ID->getEventKey("dep-direction"); )
             NANOS_INSTRUMENT ( _insKeyDeps[2] = ID->getEventKey("dep-address"); )
-            NANOS_INSTRUMENT ( _insKeyDeps[3] = ID->getEventKey("dep-range-start"); )
-            NANOS_INSTRUMENT ( _insKeyDeps[4] = ID->getEventKey("dep-range-end" ); )
+            NANOS_INSTRUMENT ( _insKeyDeps[3] = ID->getEventKey("dep-overlap-start"); )
+            NANOS_INSTRUMENT ( _insKeyDeps[4] = ID->getEventKey("dep-overlap-end" ); )
          }
    };
 

--- a/src/plugins/deps/cregions_deps.cpp
+++ b/src/plugins/deps/cregions_deps.cpp
@@ -117,7 +117,7 @@ namespace nanos {
                for ( ; vectorIdx < vectorEnd ; ++vectorIdx ) {
                    std::pair < DepsRegion, TrackableObject*> item=_addressDependencyVector.at(vectorIdx);
                    if ( item.first.overlap(target) ) {
-                     std::pair<void*, void*> overlap_range = item.first.getOverlapRange(static_cast<const DepsRegion&>(target));
+                     std::pair<void*, void*> overlap_range = item.first.computeOverlap(static_cast<const DepsRegion&>(target));
                      item.second->setDataRange(overlap_range);
                      objs->push_back(item.second);
                    } 
@@ -151,7 +151,7 @@ namespace nanos {
                     SizesMap::iterator endIter=_addressDependencySmall.upper_bound(finalAddr);
                     for ( ; startingIter!=_addressDependencySmall.end() && startingIter != endIter; ++startingIter ) {
                         if ( startingIter->first.overlap(target) ) {
-                            std::pair<void*, void*> overlap_range = startingIter->first.getOverlapRange(static_cast<const DepsRegion&>(target));
+                            std::pair<void*, void*> overlap_range = startingIter->first.computeOverlap(static_cast<const DepsRegion&>(target));
                             startingIter->second->setDataRange(overlap_range);
                             result->push_back(startingIter->second); 
                         } 
@@ -170,7 +170,7 @@ namespace nanos {
                     SizesMap::iterator endIter=_addressDependencyMid.upper_bound(finalAddr);
                     for ( ; startingIter!=_addressDependencyMid.end() && startingIter != endIter; ++startingIter ) {
                         if ( startingIter->first.overlap(target) ) {
-                            std::pair<void*, void*> overlap_range = startingIter->first.getOverlapRange(static_cast<const DepsRegion&>(target));
+                            std::pair<void*, void*> overlap_range = startingIter->first.computeOverlap(static_cast<const DepsRegion&>(target));
                             startingIter->second->setDataRange(overlap_range);
                             result->push_back(startingIter->second); 
                         } 

--- a/src/plugins/deps/cregions_deps.cpp
+++ b/src/plugins/deps/cregions_deps.cpp
@@ -117,7 +117,9 @@ namespace nanos {
                for ( ; vectorIdx < vectorEnd ; ++vectorIdx ) {
                    std::pair < DepsRegion, TrackableObject*> item=_addressDependencyVector.at(vectorIdx);
                    if ( item.first.overlap(target) ) {
-                        objs->push_back(item.second); 
+                       uint64_t overlap_size = item.first.overlapSize(static_cast<const DepsRegion&>(target));
+                       item.second->setDataSize(overlap_size);
+                       objs->push_back(item.second); 
                    } 
                }
                (*result)=*objs;
@@ -149,7 +151,9 @@ namespace nanos {
                     SizesMap::iterator endIter=_addressDependencySmall.upper_bound(finalAddr);
                     for ( ; startingIter!=_addressDependencySmall.end() && startingIter != endIter; ++startingIter ) {
                         if ( startingIter->first.overlap(target) ) {
-                             result->push_back(startingIter->second); 
+                            uint64_t overlap_size = startingIter->first.overlapSize(static_cast<const DepsRegion&>(target));
+                            startingIter->second->setDataSize(overlap_size);
+                            result->push_back(startingIter->second); 
                         } 
                     }
                 }
@@ -166,7 +170,9 @@ namespace nanos {
                     SizesMap::iterator endIter=_addressDependencyMid.upper_bound(finalAddr);
                     for ( ; startingIter!=_addressDependencyMid.end() && startingIter != endIter; ++startingIter ) {
                         if ( startingIter->first.overlap(target) ) {
-                             result->push_back(startingIter->second); 
+                            uint64_t overlap_size = startingIter->first.overlapSize(static_cast<const DepsRegion&>(target));
+                            startingIter->second->setDataSize(overlap_size);
+                            result->push_back(startingIter->second); 
                         } 
                     }
                 }

--- a/src/plugins/deps/cregions_deps.cpp
+++ b/src/plugins/deps/cregions_deps.cpp
@@ -117,8 +117,8 @@ namespace nanos {
                for ( ; vectorIdx < vectorEnd ; ++vectorIdx ) {
                    std::pair < DepsRegion, TrackableObject*> item=_addressDependencyVector.at(vectorIdx);
                    if ( item.first.overlap(target) ) {
-                     std::pair<void*, void*> overlap_range = item.first.computeOverlap(static_cast<const DepsRegion&>(target));
-                     item.second->setDataRange(overlap_range);
+                     std::pair<void*, void*> const overlap_range = item.first.computeOverlap(static_cast<const DepsRegion&>(target));
+                     item.second->setOverlapRange(overlap_range);
                      objs->push_back(item.second);
                    } 
                }
@@ -151,8 +151,8 @@ namespace nanos {
                     SizesMap::iterator endIter=_addressDependencySmall.upper_bound(finalAddr);
                     for ( ; startingIter!=_addressDependencySmall.end() && startingIter != endIter; ++startingIter ) {
                         if ( startingIter->first.overlap(target) ) {
-                            std::pair<void*, void*> overlap_range = startingIter->first.computeOverlap(static_cast<const DepsRegion&>(target));
-                            startingIter->second->setDataRange(overlap_range);
+                            std::pair<void*, void*> const overlap_range = startingIter->first.computeOverlap(static_cast<const DepsRegion&>(target));
+                            startingIter->second->setOverlapRange(overlap_range);
                             result->push_back(startingIter->second); 
                         } 
                     }
@@ -170,8 +170,8 @@ namespace nanos {
                     SizesMap::iterator endIter=_addressDependencyMid.upper_bound(finalAddr);
                     for ( ; startingIter!=_addressDependencyMid.end() && startingIter != endIter; ++startingIter ) {
                         if ( startingIter->first.overlap(target) ) {
-                            std::pair<void*, void*> overlap_range = startingIter->first.computeOverlap(static_cast<const DepsRegion&>(target));
-                            startingIter->second->setDataRange(overlap_range);
+                            std::pair<void*, void*> const overlap_range = startingIter->first.computeOverlap(static_cast<const DepsRegion&>(target));
+                            startingIter->second->setOverlapRange(overlap_range);
                             result->push_back(startingIter->second); 
                         } 
                     }

--- a/src/plugins/deps/cregions_deps.cpp
+++ b/src/plugins/deps/cregions_deps.cpp
@@ -117,9 +117,9 @@ namespace nanos {
                for ( ; vectorIdx < vectorEnd ; ++vectorIdx ) {
                    std::pair < DepsRegion, TrackableObject*> item=_addressDependencyVector.at(vectorIdx);
                    if ( item.first.overlap(target) ) {
-                       uint64_t overlap_size = item.first.overlapSize(static_cast<const DepsRegion&>(target));
-                       item.second->setDataSize(overlap_size);
-                       objs->push_back(item.second); 
+                     std::pair<void*, void*> overlap_range = item.first.getOverlapRange(static_cast<const DepsRegion&>(target));
+                     item.second->setDataRange(overlap_range);
+                     objs->push_back(item.second);
                    } 
                }
                (*result)=*objs;
@@ -151,8 +151,8 @@ namespace nanos {
                     SizesMap::iterator endIter=_addressDependencySmall.upper_bound(finalAddr);
                     for ( ; startingIter!=_addressDependencySmall.end() && startingIter != endIter; ++startingIter ) {
                         if ( startingIter->first.overlap(target) ) {
-                            uint64_t overlap_size = startingIter->first.overlapSize(static_cast<const DepsRegion&>(target));
-                            startingIter->second->setDataSize(overlap_size);
+                            std::pair<void*, void*> overlap_range = startingIter->first.getOverlapRange(static_cast<const DepsRegion&>(target));
+                            startingIter->second->setDataRange(overlap_range);
                             result->push_back(startingIter->second); 
                         } 
                     }
@@ -170,8 +170,8 @@ namespace nanos {
                     SizesMap::iterator endIter=_addressDependencyMid.upper_bound(finalAddr);
                     for ( ; startingIter!=_addressDependencyMid.end() && startingIter != endIter; ++startingIter ) {
                         if ( startingIter->first.overlap(target) ) {
-                            uint64_t overlap_size = startingIter->first.overlapSize(static_cast<const DepsRegion&>(target));
-                            startingIter->second->setDataSize(overlap_size);
+                            std::pair<void*, void*> overlap_range = startingIter->first.getOverlapRange(static_cast<const DepsRegion&>(target));
+                            startingIter->second->setDataRange(overlap_range);
                             result->push_back(startingIter->second); 
                         } 
                     }

--- a/src/plugins/instrumentation/tg_dump.cpp
+++ b/src/plugins/instrumentation/tg_dump.cpp
@@ -948,8 +948,8 @@ public:
         static const nanos_event_key_t dependence = iD->getEventKey("dependence");
         static const nanos_event_key_t dep_direction = iD->getEventKey("dep-direction");
         static const nanos_event_key_t dep_address = iD->getEventKey("dep-address");
-        static const nanos_event_key_t dep_overlap_start = iD->getEventKey("dep-range-start");
-        static const nanos_event_key_t dep_overlap_end = iD->getEventKey("dep-range-end");
+        static const nanos_event_key_t dep_overlap_start = iD->getEventKey("dep-overlap-start");
+        static const nanos_event_key_t dep_overlap_end = iD->getEventKey("dep-overlap-end");
         static const nanos_event_key_t user_funct_location = iD->getEventKey("user-funct-location");
         static const nanos_event_key_t taskwait = iD->getEventKey("taskwait");
         static const nanos_event_key_t critical_wd_id = iD->getEventKey("critical-wd-id");

--- a/src/plugins/instrumentation/tg_dump.cpp
+++ b/src/plugins/instrumentation/tg_dump.cpp
@@ -25,6 +25,7 @@
 #include "plugin.hpp"
 #include "smpdd.hpp"
 #include "system.hpp"
+#include "papi.h"
 
 #include <cassert>
 #include <cmath>
@@ -463,6 +464,13 @@ public:
     void initialize(void)
     {
         _root = new Node(0, 0, Root);
+        
+        // Initialise PAPI
+        int rc;
+        if((rc = PAPI_library_init(PAPI_VER_CURRENT)) != PAPI_VER_CURRENT) {
+            std::cerr << "Failed to initialise PAPI!\n";
+            exit(1);
+        }
     }
 
     void finalize(void)
@@ -537,6 +545,9 @@ public:
         // TODO
         // Print the summarized graph
 //         print_summarized_graph(file_name);
+
+        // Shut down papi
+        PAPI_shutdown();
     }
 
     void disable(void) {}

--- a/src/plugins/instrumentation/tg_dump.cpp
+++ b/src/plugins/instrumentation/tg_dump.cpp
@@ -479,8 +479,40 @@ private:
             printJsonAttribute(indent + "  ", "type", "Usertask", ss);
             ss << ",\n";
 
-            printJsonAttribute(indent + "  ", "description", _funct_id_to_decl_map[n->get_funct_id()], ss);
-            ss << ",\n";
+            std::string description = _funct_id_to_decl_map[n->get_funct_id()];
+            std::vector<std::string> desc_sections;
+            desc_sections.reserve(4);
+
+            size_t end;
+            while ((end = description.find_first_of("@")) != std::string::npos) {
+                desc_sections.push_back(description.substr(0, end));
+                description = description.substr(end + 1);
+            }
+            desc_sections.push_back(description);
+
+            // If the format of the description is correct, print attributes
+            if (desc_sections.size() == 4 && (desc_sections[3] == "LABEL" || desc_sections[3] == "FUNCTION")) {
+                if (desc_sections[3] == "LABEL") {
+                    printJsonAttribute(indent + "  ", "label", desc_sections[0], ss);
+                } else {
+                    printJsonNullAttribute(indent + "  ", "label", ss);
+                }
+                ss << ",\n";
+
+                printJsonAttribute(indent + "  ", "file", desc_sections[1], ss);
+                ss << ",\n";
+
+                int line_number;
+                std::istringstream(desc_sections[2]) >> line_number;
+                printJsonAttribute(indent + "  ", "line", line_number, ss);
+                ss << ",\n";
+            }
+
+            // Else, print the whole description
+            else {
+                printJsonAttribute(indent + "  ", "description", description, ss);
+                ss << ",\n";
+            }
 
             printJsonAttribute(indent + "  ", "critical", n->is_critical(), ss);
             ss << ",\n";

--- a/src/plugins/instrumentation/tg_dump.cpp
+++ b/src/plugins/instrumentation/tg_dump.cpp
@@ -121,10 +121,10 @@ private:
         edge_attrs += ( (e->get_source()->is_critical() && e->get_target()->is_critical()) ? ",bold" : "" );
  
         // Compute the color of the edge
-        edge_attrs += "\", color=\"";
-        edge_attrs += (e->is_nesting() ? "gray47" 
-                                       : "black");
-        edge_attrs += "\"";
+        edge_attrs += "\", color=";
+        edge_attrs += (e->is_nesting() ? "\"gray47\"" : "\"black\"");
+        
+        edge_attrs += ", data_size=\"" + toString(e->get_data_size()) + "\"";
         
         // Print the edge
         std::stringstream sss; sss << e->get_source()->get_wd_id();

--- a/src/plugins/instrumentation/tg_dump.cpp
+++ b/src/plugins/instrumentation/tg_dump.cpp
@@ -107,6 +107,23 @@ private:
         // Output execution time
         node_attrs += ", execution_time=\"" + toString(n->get_total_time()) + "\"";
 
+        // Output papi operation counters
+        std::vector<std::pair<int, long long> > perf_counters = n->get_perf_counters();
+        std::vector<std::pair<int, long long> >::iterator it;
+        for(it = perf_counters.begin(); it != perf_counters.end(); ++it) {
+            char papi_event_name[PAPI_MAX_STR_LEN];
+            int rc;
+            
+            if((rc = PAPI_event_code_to_name(it->first, papi_event_name)) != PAPI_OK) {
+                std::cerr << "Failed to get name for event id " << it->first << ". ";
+                std::cerr << "Papi error: (" << rc << ") - " << PAPI_strerror(rc) << ". ";
+                std::cerr << "The associated counter will not be emitted.\n";
+                continue;
+            }
+            
+            node_attrs += ", " + std::string(papi_event_name) + "=\"" + toString(it->second) + "\"";
+        }
+
         // Build and return the whole node info
         std::stringstream ss; ss << n->get_wd_id();
         return std::string(indentation + ss.str()) + "[" + node_attrs + "];\n";

--- a/src/plugins/instrumentation/tg_dump.cpp
+++ b/src/plugins/instrumentation/tg_dump.cpp
@@ -70,9 +70,9 @@ private:
         else if(current_thread->getCurrentWD() == NULL) return 0;
         return current_thread->getCurrentWD()->getId();
     }
-    
+
     inline std::string print_node(Node* n, std::string indentation) {
-        
+
         std::string node_attrs = "";
         // Get the label of the node
 //         std::stringstream ss; ss << n->get_wd_id();
@@ -82,12 +82,12 @@ private:
         } else if (n->is_barrier()) {
             node_attrs += "label=\"Barrier\", ";
         }
-        
+
         // Get the style of the node
         node_attrs += "style=\"";
         node_attrs += (!n->is_task() ? "bold" : "filled");
         node_attrs += (n->is_task() && n->is_critical() ? ",bold\", shape=\"doublecircle" : "");    //Mark critical tasks as bold and filled
-        
+
         // Get the color of the node
  //       if(n->is_task() && n->is_critical()) {
  //           node_attrs += "\", color=\"black\", fillcolor=red\"";// + wd_to_color_hash(n->get_funct_id());
@@ -96,42 +96,42 @@ private:
             std::string description = _funct_id_to_decl_map[n->get_funct_id()];
             node_attrs += "\", color=\"black\", fillcolor=\"" + wd_to_color_hash(description);
         }
-        
+
         // Set the size of the node
         node_attrs += "\", width=\"1\", height=\"1\"";
-        
+
         // Output execution time
         node_attrs += ", execution_time=\"" + toString(n->get_total_time()) + "\"";
-                
+
         // Build and return the whole node info
         std::stringstream ss; ss << n->get_wd_id();
         return std::string(indentation + ss.str()) + "[" + node_attrs + "];\n";
     }
-    
+
     inline std::string print_edge(Edge* e, std::string indentation)
     {
 
         std::string edge_attrs = "style=\"";
-        
+
         // Compute the style of the edge
-        edge_attrs += ((!e->is_dependency() || 
+        edge_attrs += ((!e->is_dependency() ||
                         e->is_true_dependency()) ? "solid" : (e->is_anti_dependency() ? "dashed" : "dotted"));
 
         //Mark the edges of the critical path as bold
         edge_attrs += ( (e->get_source()->is_critical() && e->get_target()->is_critical()) ? ",bold" : "" );
- 
+
         // Compute the color of the edge
         edge_attrs += "\", color=";
         edge_attrs += (e->is_nesting() ? "\"gray47\"" : "\"black\"");
-        
+
         edge_attrs += ", data_size=\"" + toString(e->get_data_size()) + "\"";
-        
+
         // Print the edge
         std::stringstream sss; sss << e->get_source()->get_wd_id();
         std::stringstream sst; sst << e->get_target()->get_wd_id();
         return std::string(indentation + sss.str() + " -> " + sst.str() + " [" + edge_attrs + "];\n");
     }
-    
+
     inline std::string print_nested_nodes(Node* n, std::string indentation) {
         std::string nested_nodes_info = "";
         std::vector<Edge*> const& exits = n->get_exits();
@@ -148,9 +148,9 @@ private:
         }
         return nested_nodes_info;
     }
-    
+
     inline std::string print_edges_legend() {
-        std::stringstream ss; 
+        std::stringstream ss;
         lock.acquire();
             ss << cluster_id++;
         lock.release();
@@ -209,7 +209,7 @@ private:
 
         return edges_legend;
     }
-    
+
     inline std::string print_nodes_legend() {
         std::stringstream ssc;
         lock.acquire();
@@ -257,7 +257,7 @@ private:
         nodes_legend += "  }\n";
         return nodes_legend;
     }
-    
+
     inline Node* find_node_from_wd_id(int64_t wd_id) const {
         Node* result = NULL;
         for(std::set<Node*>::const_iterator it = _graph_nodes.begin(); it != _graph_nodes.end(); ++it) {
@@ -268,7 +268,7 @@ private:
         }
         return result;
     }
-    
+
     inline std::string print_node_and_its_nested(Node* n, std::string indentation) {
         std::string result = "";
         // Print the current node
@@ -276,7 +276,7 @@ private:
         n->set_printed();
         // Print all nested nodes
         std::string nested_nodes_info = print_nested_nodes(n, /*indentation*/"    ");
-        
+
         if(nested_nodes_info.empty()) {
             result = node_info;
         } else {
@@ -294,13 +294,13 @@ private:
         // Generate the name of the dot file from the name of the binary
         std::string result = partial_file_name + "_full";
         std::string file_name = result + ".dot";
-        
+
         // Open the file and start the graph
         std::ofstream dot_file;
         dot_file.open(file_name.c_str());
         if(!dot_file.is_open())
             exit(EXIT_FAILURE);
-        
+
         // Print the graph
         std::map<int, int> node_to_cluster;
         dot_file << "digraph {\n";
@@ -414,25 +414,25 @@ private:
                     }
                 }
             }
-            
+
             // Print the legends
             dot_file << "  node [shape=plaintext];\n";
             dot_file << print_nodes_legend();
             dot_file << print_edges_legend();
         dot_file << "}";
-        
+
         std::cerr << "Task Dependency Graph printed to file '" << file_name << "' in DOT format" << std::endl;
         return result;
     }
-    
+
 #ifndef NANOS_INSTRUMENTATION_ENABLED
 public:
     // constructor
     InstrumentationTGDump() : Instrumentation(),
-                                          _graph_nodes(), _funct_id_to_decl_map(), 
+                                          _graph_nodes(), _funct_id_to_decl_map(),
                                           _min_time(HUGE_VAL), _total_time(0.0), _min_diam(1.0)
     {}
-    
+
     // destructor
     ~InstrumentationTGDump() {}
 
@@ -448,23 +448,23 @@ public:
     void threadFinish (BaseThread &thread) {}
 #else
 public:
-    
+
     // constructor
     InstrumentationTGDump() : Instrumentation(*new InstrumentationContextDisabled()),
-                                          _graph_nodes(), _funct_id_to_decl_map(), 
+                                          _graph_nodes(), _funct_id_to_decl_map(),
                                           _min_time(HUGE_VAL), _total_time(0.0), _min_diam(1.0),
                                           _next_tw_id(0), _next_conc_id(0)
     {}
-    
+
     // destructor
     ~InstrumentationTGDump () {}
 
     // low-level instrumentation interface (mandatory functions)
-    void initialize(void) 
+    void initialize(void)
     {
         _root = new Node(0, 0, Root);
     }
-    
+
     void finalize(void)
     {
         // So far, taskwaits have been synchronized with the tasks created previously
@@ -500,7 +500,7 @@ public:
                 }
             }
         }
-        
+
         // Get partial name of the file that will contain the dot graph
         std::string unique_key_name;
         time_t t = time(NULL);
@@ -518,22 +518,22 @@ public:
                 unique_key_name = std::string(outstr);
             }
         }
-        
+
         std::string file_name = OS::getArg(0);
         size_t slash_pos = file_name.find_last_of("/");
         if(slash_pos != std::string::npos)
             file_name = file_name.substr(slash_pos+1, file_name.size()-slash_pos);
         file_name = file_name + "_" + unique_key_name;
-        
+
         // Print the full graph
         std::string full_dot_name = print_full_graph(file_name);
-        
+
         // Generate the PDF containing the graph
         std::string dot_to_pdf_command = "dot -Tpdf " + full_dot_name + ".dot -o " + full_dot_name + ".pdf";
         if ( system( dot_to_pdf_command.c_str( ) ) != 0 )
             warning( "Could not create the pdf file." );
         std::cerr << "Task Dependency Graph printed to file '" << full_dot_name << ".pdf' in PDF format" << std::endl;
-        
+
         // TODO
         // Print the summarized graph
 //         print_summarized_graph(file_name);
@@ -646,7 +646,7 @@ public:
                 // Get the identifiers of the sender and the receiver
                 int64_t sender_wd_id = (int64_t) ((e.getValue() >> 32) & 0xFFFFFFFF);
                 int64_t receiver_wd_id = (int64_t) (e.getValue() & 0xFFFFFFFF);
-                
+
                 // Get the type of dependence
                 e = events[++i];
                 assert(e.getKey() == dep_direction);
@@ -690,7 +690,7 @@ public:
                 if(sender == NULL || receiver == NULL) {
                     // Compute the type for the new node
                     NodeType nt = (((dep_type == InConcurrent) || (dep_type == OutConcurrent)) ? ConcurrentNode : CommutativeNode);
-                    
+
                     // Create the new sender node, if necessary
                     if(sender == NULL) {
                         sender = new Node(sender_wd_id, 0, nt);
@@ -698,7 +698,7 @@ public:
                         _graph_nodes.insert(sender);
                         _graph_nodes_lock.release();
                     }
-                    
+
                     // Create the new receiver node, if necessary
                     if(receiver == NULL) {
                         receiver = new Node(receiver_wd_id, 0, nt);
@@ -742,23 +742,23 @@ public:
 };
 
 namespace ext {
-    
+
     class InstrumentationTGDumpPlugin : public Plugin {
     public:
         InstrumentationTGDumpPlugin () : Plugin("Instrumentation plugin which prints the graph to a dot file.", 1) {}
         ~InstrumentationTGDumpPlugin () {}
-        
-        void config(Config &cfg) 
+
+        void config(Config &cfg)
         {
-           
+
         }
-        
+
         void init ()
         {
             sys.setInstrumentation(new InstrumentationTGDump());
         }
     };
-    
+
 } // namespace ext
 
 } // namespace nanos

--- a/src/plugins/instrumentation/tg_dump.cpp
+++ b/src/plugins/instrumentation/tg_dump.cpp
@@ -526,10 +526,8 @@ private:
             // Output
             std::vector<NodeIO> io = n->get_io();
             if (io.size() != 0) {
+                ss << indent << "  " << "\"io\": [\n";
                 for (std::vector<NodeIO>::iterator it = io.begin(); it != io.end(); ++it) {
-                    if(it == io.begin()) {
-                        ss << indent << "  " << "\"node_io\": [\n";
-                    }
                     it->to_json(indent + "  " + "  ", ss);
                     if((it + 1) != io.end()) {
                         ss << ",\n";
@@ -537,7 +535,7 @@ private:
                 }
                 ss << "\n" << indent << "  " << "],\n";
             } else {
-                printJsonNullAttribute(indent + "  ", "node_io", ss);
+                printJsonNullAttribute(indent + "  ", "io", ss);
                 ss << ",\n";
             }
 

--- a/src/plugins/instrumentation/tg_dump.cpp
+++ b/src/plugins/instrumentation/tg_dump.cpp
@@ -566,6 +566,7 @@ public:
         Node* n = find_node_from_wd_id(w.getId());
         if(n != NULL) {
             n->set_last_time(get_current_time());
+            n->start_operation_counters();
         }
     }
 
@@ -573,6 +574,7 @@ public:
     {
         Node* n = find_node_from_wd_id(w.getId());
         if(n != NULL) {
+            n->suspend_operation_counters();
             double time = (double) get_current_time() - n->get_last_time();
             n->add_total_time(time);
         }

--- a/src/plugins/instrumentation/tg_dump.cpp
+++ b/src/plugins/instrumentation/tg_dump.cpp
@@ -526,8 +526,7 @@ private:
 
             papi_counter_data_printable.reserve(papi_counter_data.size());
 
-            std::vector<std::pair<int, long long> >::iterator it;
-            for(it = papi_counter_data.begin(); it != papi_counter_data.end(); ++it) {
+            for(std::vector<std::pair<int, long long> >::iterator it = papi_counter_data.begin(); it != papi_counter_data.end(); ++it) {
                 char papi_event_name[PAPI_MAX_STR_LEN];
                 int rc;
 
@@ -542,31 +541,30 @@ private:
             }
 
             printJsonAttributeArray(indent + "  ", "papi_counters", papi_counter_data_printable, ss);
-        }
-        ss << ",\n";
+            ss << ",\n";
 
-        // Get nested exits
-        std::vector<Edge*> const& exits = n->get_exits();
-        std::vector<Edge*> nested_exits;
-        nested_exits.reserve(exits.size());
+            // Get nested exits
+            std::vector<Edge*> const& exits = n->get_exits();
+            std::vector<Edge*> nested_exits;
+            nested_exits.reserve(exits.size());
 
-        for(std::vector<Edge*>::const_iterator it = exits.begin(); it != exits.end(); ++it) {
-            if((*it)->is_nesting()) {
-                nested_exits.push_back(*it);
+            for(std::vector<Edge*>::const_iterator it = exits.begin(); it != exits.end(); ++it) {
+                if((*it)->is_nesting()) {
+                    nested_exits.push_back(*it);
+                }
+            }
+
+            // If we have nested exits, print subgraph
+            if(nested_exits.size() != 0) {
+                ss << indent + "  " << "\"subgraph\": {\n";
+                ss << print_graph_objects_json(n, indent + "  " + "  ", true) << "\n";
+                ss << indent + "  " << "}";
+            } else {
+                printJsonNullAttribute(indent + "  ", "subgraph", ss);
             }
         }
 
-        // If we have nested exits, print subgraph
-        if(nested_exits.size() != 0) {
-            ss << indent + "  " << "\"subgraph\": {\n";
-            ss << print_graph_objects_json(n, indent + "  " + "  ", true) << "\n";
-            ss << indent + "  " << "}";
-        } else {
-            printJsonNullAttribute(indent + "  ", "subgraph", ss);
-        }
-
         ss << "\n" << indent << "}";
-
         return ss.str();
     }
 

--- a/src/plugins/instrumentation/tg_dump.cpp
+++ b/src/plugins/instrumentation/tg_dump.cpp
@@ -1015,24 +1015,30 @@ public:
             {   // A user function has been called
                 int64_t func_id = e.getValue();
                 _funct_id_to_decl_map_lock.acquire();
-                if(func_id != 0 && _funct_id_to_decl_map.find(func_id) == _funct_id_to_decl_map.end()) {
-                    // description = func_type|func_label @ file @ line @ name_type
-                    // If name_type == LABEL -> description = func_type|func_label
-                    // else if name_type == FUNCTION -> description = func_type|func_label @ file @ line
+                if (func_id != 0 && _funct_id_to_decl_map.find(func_id) == _funct_id_to_decl_map.end()) {
                     std::string description = iD->getValueDescription(user_funct_location, func_id);
-                    int pos2 = description.find_first_of("@");
-                    int pos3 = description.find_last_of("@")+1;
-                    int pos4 = description.length();
-                    std::string type = description.substr(pos3, pos4-pos3);
-                    if (type == "LABEL")
-                    {
-                        // description = func_label                -> only store the label
-                        _funct_id_to_decl_map[ func_id ] = description.substr(0, pos2);
-                    }
-                    else    // type == "FUNCTION"
-                    {
-                        // description = func_type @ file @ line   -> store the whole description
-                        _funct_id_to_decl_map[ func_id ] = description.substr(0, pos3);
+                    if (_output_mode == "pdf") {
+                        // description = func_type|func_label @ file @ line @ name_type
+                        // If name_type == LABEL -> description = func_type|func_label
+                        // else if name_type == FUNCTION -> description = func_type|func_label @ file @ line
+                        int pos2 = description.find_first_of("@");
+                        int pos3 = description.find_last_of("@")+1;
+                        int pos4 = description.length();
+                        std::string type = description.substr(pos3, pos4-pos3);
+                        if (type == "LABEL")
+                        {
+                            // description = func_label                -> only store the label
+                            _funct_id_to_decl_map[ func_id ] = description.substr(0, pos2);
+                        }
+                        else    // type == "FUNCTION"
+                        {
+                            // description = func_type @ file @ line   -> store the whole description
+                            _funct_id_to_decl_map[ func_id ] = description.substr(0, pos3);
+                        }
+                    } else if(_output_mode == "json") {
+                        _funct_id_to_decl_map[ func_id ] = description;
+                    } else {
+                        _funct_id_to_decl_map[ func_id ] = description;
                     }
                 }
                 _funct_id_to_decl_map_lock.release();

--- a/src/plugins/instrumentation/tg_dump.cpp
+++ b/src/plugins/instrumentation/tg_dump.cpp
@@ -76,36 +76,34 @@ private:
     }
 
     inline std::string print_node(Node* n, std::string indentation) {
-
-        std::string node_attrs = "";
+        std::stringstream ss;
+        
+        // Create node label and open attribute braces
+        ss << indentation << n->get_wd_id() << "[";
+        
         // Get the label of the node
-//         std::stringstream ss; ss << n->get_wd_id();
         if (n->is_taskwait()) {
-            node_attrs += "label=\"Taskwait\", ";
-//             node_attrs += "label=\"[" + ss.str() + "]Taskwait\", ";
+            ss << "label=\"Taskwait\", ";
         } else if (n->is_barrier()) {
-            node_attrs += "label=\"Barrier\", ";
+            ss << "label=\"Barrier\", ";
         }
 
         // Get the style of the node
-        node_attrs += "style=\"";
-        node_attrs += (!n->is_task() ? "bold" : "filled");
-        node_attrs += (n->is_task() && n->is_critical() ? ",bold\", shape=\"doublecircle" : "");    //Mark critical tasks as bold and filled
+        ss << "style=\"";
+        ss << (!n->is_task() ? "bold" : "filled");
+        ss << (n->is_task() && n->is_critical() ? ",bold\", shape=\"doublecircle" : "");    //Mark critical tasks as bold and filled
 
         // Get the color of the node
- //       if(n->is_task() && n->is_critical()) {
- //           node_attrs += "\", color=\"black\", fillcolor=red\"";// + wd_to_color_hash(n->get_funct_id());
- //       }
         if(n->is_task()) {
             std::string description = _funct_id_to_decl_map[n->get_funct_id()];
-            node_attrs += "\", color=\"black\", fillcolor=\"" + wd_to_color_hash(description);
+            ss << "\", color=\"black\", fillcolor=\"" << wd_to_color_hash(description);
         }
 
         // Set the size of the node
-        node_attrs += "\", width=\"1\", height=\"1\"";
+        ss << "\", width=\"1\", height=\"1\"";
 
         // Output execution time
-        node_attrs += ", execution_time=\"" + toString(n->get_total_time()) + "\"";
+        ss << ", execution_time=\"" << n->get_total_time() << "\"";
 
         // Output papi operation counters
         std::vector<std::pair<int, long long> > perf_counters = n->get_perf_counters();
@@ -121,12 +119,13 @@ private:
                 continue;
             }
             
-            node_attrs += ", " + std::string(papi_event_name) + "=\"" + toString(it->second) + "\"";
+            ss << ", " << std::string(papi_event_name) << "=\"" << toString(it->second) << "\"";
         }
 
-        // Build and return the whole node info
-        std::stringstream ss; ss << n->get_wd_id();
-        return std::string(indentation + ss.str()) + "[" + node_attrs + "];\n";
+        // Close the braces around the node attributes
+        ss << "];\n";
+        
+        return ss.str();
     }
 
     inline std::string print_edge(Edge* e, std::string indentation)

--- a/src/plugins/instrumentation/tg_dump.cpp
+++ b/src/plugins/instrumentation/tg_dump.cpp
@@ -597,16 +597,6 @@ public:
         // Print the full graph
         std::string full_dot_name = print_full_graph(file_name);
 
-        // Generate the PDF containing the graph
-        std::string dot_to_pdf_command = "dot -Tpdf " + full_dot_name + ".dot -o " + full_dot_name + ".pdf";
-        if ( system( dot_to_pdf_command.c_str( ) ) != 0 )
-            warning( "Could not create the pdf file." );
-        std::cerr << "Task Dependency Graph printed to file '" << full_dot_name << ".pdf' in PDF format" << std::endl;
-
-        // TODO
-        // Print the summarized graph
-//         print_summarized_graph(file_name);
-
         // Shut down papi
         PAPI_shutdown();
     }

--- a/src/plugins/instrumentation/tg_dump.cpp
+++ b/src/plugins/instrumentation/tg_dump.cpp
@@ -100,6 +100,9 @@ private:
         // Set the size of the node
         node_attrs += "\", width=\"1\", height=\"1\"";
         
+        // Output execution time
+        node_attrs += ", execution_time=\"" + toString(n->get_total_time()) + "\"";
+                
         // Build and return the whole node info
         std::stringstream ss; ss << n->get_wd_id();
         return std::string(indentation + ss.str()) + "[" + node_attrs + "];\n";

--- a/src/plugins/instrumentation/tg_dump.cpp
+++ b/src/plugins/instrumentation/tg_dump.cpp
@@ -517,14 +517,17 @@ private:
             printJsonAttribute(indent + "  ", "critical", n->is_critical(), ss);
             ss << ",\n";
 
-            // Output papi operation counts
-            std::vector<std::pair<int, long long> > perf_counter_data = n->get_perf_counters();
-            std::vector<std::pair<std::string, long long> > perf_counter_data_printable;
+            printJsonAttribute(indent + "  ", "duration_us", n->get_total_time(), ss);
+            ss << ",\n";
 
-            perf_counter_data_printable.reserve(perf_counter_data.size());
+            // Output papi operation counts
+            std::vector<std::pair<int, long long> > papi_counter_data = n->get_perf_counters();
+            std::vector<std::pair<std::string, long long> > papi_counter_data_printable;
+
+            papi_counter_data_printable.reserve(papi_counter_data.size());
 
             std::vector<std::pair<int, long long> >::iterator it;
-            for(it = perf_counter_data.begin(); it != perf_counter_data.end(); ++it) {
+            for(it = papi_counter_data.begin(); it != papi_counter_data.end(); ++it) {
                 char papi_event_name[PAPI_MAX_STR_LEN];
                 int rc;
 
@@ -535,12 +538,10 @@ private:
                     continue;
                 }
 
-                perf_counter_data_printable.push_back(std::make_pair(std::string(papi_event_name), it->second));
+                papi_counter_data_printable.push_back(std::make_pair(std::string(papi_event_name), it->second));
             }
 
-            perf_counter_data_printable.push_back(std::make_pair("duration_us", n->get_total_time()));
-
-            printJsonAttributeArray(indent + "  ", "perf_data", perf_counter_data_printable, ss);
+            printJsonAttributeArray(indent + "  ", "papi_counters", papi_counter_data_printable, ss);
         }
         ss << ",\n";
 

--- a/src/plugins/instrumentation/tg_dump.cpp
+++ b/src/plugins/instrumentation/tg_dump.cpp
@@ -1,0 +1,812 @@
+/*************************************************************************************/
+/*      Copyright 2009-2018 Barcelona Supercomputing Center                          */
+/*                                                                                   */
+/*      This file is part of the NANOS++ library.                                    */
+/*                                                                                   */
+/*      NANOS++ is free software: you can redistribute it and/or modify              */
+/*      it under the terms of the GNU Lesser General Public License as published by  */
+/*      the Free Software Foundation, either version 3 of the License, or            */
+/*      (at your option) any later version.                                          */
+/*                                                                                   */
+/*      NANOS++ is distributed in the hope that it will be useful,                   */
+/*      but WITHOUT ANY WARRANTY; without even the implied warranty of               */
+/*      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                */
+/*      GNU Lesser General Public License for more details.                          */
+/*                                                                                   */
+/*      You should have received a copy of the GNU Lesser General Public License     */
+/*      along with NANOS++.  If not, see <https://www.gnu.org/licenses/>.            */
+/*************************************************************************************/
+
+#include "tg_dump_utils.hpp"
+
+#include "instrumentation.hpp"
+#include "instrumentationcontext_decl.hpp"
+#include "os.hpp"
+#include "plugin.hpp"
+#include "smpdd.hpp"
+#include "system.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <math.h>
+#include <queue>
+#include <stdlib.h>
+#include <sys/time.h>
+#include <time.h>
+
+namespace {
+    nanos::Lock lock;
+}
+
+namespace nanos {
+
+enum { concurrent_min_id = 1000000 };
+static unsigned int cluster_id = 1;
+
+class InstrumentationTGDump: public Instrumentation
+{
+public:
+    // public static data-members
+    static std::string _nodeSizeFunc;
+    
+private:
+    Node* _root;
+    std::set<Node*> _graph_nodes;                           /*!< relation between a wd id and its node in the graph */
+    Lock _graph_nodes_lock;
+    std::map<int64_t, std::string> _funct_id_to_decl_map;   /*!< relation between a task id and its name */
+    Lock _funct_id_to_decl_map_lock;
+    double _min_time;
+    double _total_time;
+    double _min_diam;
+
+#ifdef NANOS_INSTRUMENTATION_ENABLED
+    int64_t _next_tw_id;
+    int64_t _next_conc_id;
+#endif
+
+    inline int64_t getMyWDId() {
+        BaseThread *current_thread = getMyThreadSafe();
+        if(current_thread == NULL) return 0;
+        else if(current_thread->getCurrentWD() == NULL) return 0;
+        return current_thread->getCurrentWD()->getId();
+    }
+    
+    inline std::string print_node(Node* n, std::string indentation) {
+        
+        std::string node_attrs = "";
+        // Get the label of the node
+//         std::stringstream ss; ss << n->get_wd_id();
+        if (n->is_taskwait()) {
+            node_attrs += "label=\"Taskwait\", ";
+//             node_attrs += "label=\"[" + ss.str() + "]Taskwait\", ";
+        } else if (n->is_barrier()) {
+            node_attrs += "label=\"Barrier\", ";
+        }
+        
+        // Get the style of the node
+        node_attrs += "style=\"";
+        node_attrs += (!n->is_task() ? "bold" : "filled");
+        node_attrs += (n->is_task() && n->is_critical() ? ",bold\", shape=\"doublecircle" : "");    //Mark critical tasks as bold and filled
+        
+        // Get the color of the node
+ //       if(n->is_task() && n->is_critical()) {
+ //           node_attrs += "\", color=\"black\", fillcolor=red\"";// + wd_to_color_hash(n->get_funct_id());
+ //       }
+        if(n->is_task()) {
+            std::string description = _funct_id_to_decl_map[n->get_funct_id()];
+            node_attrs += "\", color=\"black\", fillcolor=\"" + wd_to_color_hash(description);
+        }
+ 
+        // Get the size of the node
+        if(InstrumentationTGDump::_nodeSizeFunc == "constant" || _total_time == 0.0)
+        {
+            node_attrs += "\", width=\"1\", height=\"1\"";
+        }
+        else
+        {
+            double diam = std::sqrt(n->get_total_time() / M_PI) * 2;
+            if(InstrumentationTGDump::_nodeSizeFunc == "linear")
+            {
+                std::stringstream ss; ss << diam / _min_diam;
+                node_attrs += "\", width=\"" + ss.str() + "\", height=\"" + ss.str() + "\"";
+            }
+            else if(InstrumentationTGDump::_nodeSizeFunc == "log")
+            {
+                std::stringstream ss; ss << std::log((diam / _min_diam) * M_E);
+                node_attrs += "\", width=\"" + ss.str() + "\", height=\"" + ss.str() + "\"";
+            }
+        }
+        
+        // Build and return the whole node info
+        std::stringstream ss; ss << n->get_wd_id();
+        return std::string(indentation + ss.str()) + "[" + node_attrs + "];\n";
+    }
+    
+    inline std::string print_edge(Edge* e, std::string indentation)
+    {
+
+        std::string edge_attrs = "style=\"";
+        
+        // Compute the style of the edge
+        edge_attrs += ((!e->is_dependency() || 
+                        e->is_true_dependency()) ? "solid" : (e->is_anti_dependency() ? "dashed" : "dotted"));
+
+        //Mark the edges of the critical path as bold
+        edge_attrs += ( (e->get_source()->is_critical() && e->get_target()->is_critical()) ? ",bold" : "" );
+ 
+        // Compute the color of the edge
+        edge_attrs += "\", color=\"";
+        edge_attrs += (e->is_nesting() ? "gray47" 
+                                       : "black");
+        edge_attrs += "\"";
+        
+        // Print the edge
+        std::stringstream sss; sss << e->get_source()->get_wd_id();
+        std::stringstream sst; sst << e->get_target()->get_wd_id();
+        return std::string(indentation + sss.str() + " -> " + sst.str() + " [" + edge_attrs + "];\n");
+    }
+    
+    inline std::string print_nested_nodes(Node* n, std::string indentation) {
+        std::string nested_nodes_info = "";
+        std::vector<Edge*> const& exits = n->get_exits();
+        std::vector<Edge*> nested_exits;
+        for(std::vector<Edge*>::const_iterator it = exits.begin(); it != exits.end(); ++it)
+        {
+            if ((*it)->is_nesting())
+            {
+                Node* t = (*it)->get_target();
+                nested_nodes_info += print_node(t, indentation) + print_edge(*it, indentation);
+                // Call recursively for nodes nested to the current node
+                print_nested_nodes(t, std::string(indentation + "  "));
+            }
+        }
+        return nested_nodes_info;
+    }
+    
+    inline std::string print_edges_legend() {
+        std::stringstream ss; 
+        lock.acquire();
+            ss << cluster_id++;
+        lock.release();
+        std::string edges_legend = "";
+
+        // Avoid printing an empty legend
+        if (!used_edge_types[0] && !used_edge_types[1] && !used_edge_types[2]
+            && !used_edge_types[3] && !used_edge_types[4])
+            return "";
+
+        // Open the subgraph containing the edge's legend
+        edges_legend += "  subgraph cluster_" + ss.str() + " {\n";
+        edges_legend += "    label=\"Edge types:\"; style=\"rounded\";\n";
+
+        // Print the table with the used edge types
+        edges_legend += "    edges_table [label=<<table border=\"0\" cellspacing=\"10\" cellborder=\"0\">\n";
+        if (used_edge_types[0])
+        {
+            edges_legend += "      <tr>\n";
+            edges_legend += "        <td width=\"15px\" border=\"0\">&#10141;</td>\n";
+            edges_legend += "        <td>True dependence | Taskwait | Barrier</td>\n";
+            edges_legend += "      </tr>\n";
+        }
+        if (used_edge_types[1])
+        {
+            edges_legend += "      <tr>\n";
+            edges_legend += "        <td width=\"15px\" border=\"0\">&#8674;</td>\n";
+            edges_legend += "        <td>Anti-dependence</td>\n";
+            edges_legend += "      </tr>\n";
+        }
+        if (used_edge_types[2])
+        {
+            edges_legend += "      <tr>\n";
+            edges_legend += "        <td width=\"15px\" border=\"0\">&#10513;</td>\n";
+            edges_legend += "        <td>Output dependence</td>\n";
+            edges_legend += "      </tr>\n";
+        }
+        if (used_edge_types[3])
+        {
+            edges_legend += "      <tr>\n";
+            edges_legend += "        <td width=\"15px\" border=\"0\"><font color=\"gray47\">&#10141;</font></td>\n";
+            edges_legend += "        <td>Nested task</td>\n";
+            edges_legend += "      </tr>\n";
+        }
+        if (used_edge_types[4])
+        {
+            edges_legend += "      <tr>\n";
+            edges_legend += "        <td width=\"15px\" border=\"0\">&#10145;</td>\n";
+            edges_legend += "        <td>Critical path</td>\n";
+            edges_legend += "      </tr>\n";
+        }
+        edges_legend += "    </table>>]\n";
+
+        // Close the node legend subgraph
+        edges_legend += "  }\n";
+
+        return edges_legend;
+    }
+    
+    inline std::string print_nodes_legend() {
+        std::stringstream ssc;
+        lock.acquire();
+        ssc << cluster_id++;
+        lock.release();
+
+        std::string nodes_legend = "";
+
+        // Avoid printing an empty legend
+        if (_funct_id_to_decl_map.empty())
+            return "";
+
+        // Open the subgraph containing the node's legend
+        nodes_legend += "  subgraph cluster_" + ssc.str() + " {\n";
+        nodes_legend += "    label=\"User functions:\"; style=\"rounded\";\n";
+        nodes_legend += "    funcs_table [label=<<table border=\"0\" cellspacing=\"10\" cellborder=\"0\">\n";
+        std::set<std::string> printed_funcs;
+        for (std::map<int64_t, std::string>::const_iterator it = _funct_id_to_decl_map.begin();
+             it != _funct_id_to_decl_map.end() ; ++it)
+        {
+            std::string description = it->second;
+            if (printed_funcs.find(description) == printed_funcs.end())
+            {
+                printed_funcs.insert(description);
+
+                // Replace any '&' with the HTML entity '&amp;'
+                std::string from = "&";
+                std::string to = "&amp;";
+                size_t start_pos = 0;
+                std::string dot_description = description;
+                while((start_pos = dot_description.find(from, start_pos)) != std::string::npos) {
+                    dot_description.replace(start_pos, from.length(), to);
+                    start_pos += to.length();
+                }
+
+                nodes_legend += "      <tr>\n";
+                nodes_legend += "        <td bgcolor=\"" + wd_to_color_hash(description) + "\" width=\"15px\" border=\"1\"></td>\n";
+                nodes_legend += "        <td>" + dot_description + "</td>\n";
+                nodes_legend += "      </tr>\n";
+            }
+        }
+        nodes_legend += "    </table>>]\n";
+
+        // Close the node legend subgraph
+        nodes_legend += "  }\n";
+        return nodes_legend;
+    }
+    
+    inline Node* find_node_from_wd_id(int64_t wd_id) const {
+        Node* result = NULL;
+        for(std::set<Node*>::const_iterator it = _graph_nodes.begin(); it != _graph_nodes.end(); ++it) {
+            if((*it)->get_wd_id() == wd_id) {
+                result = *it;
+                break;
+            }
+        }
+        return result;
+    }
+    
+    inline std::string print_node_and_its_nested(Node* n, std::string indentation) {
+        std::string result = "";
+        // Print the current node
+        std::string node_info = print_node(n, indentation);
+        n->set_printed();
+        // Print all nested nodes
+        std::string nested_nodes_info = print_nested_nodes(n, /*indentation*/"    ");
+        
+        if(nested_nodes_info.empty()) {
+            result = node_info;
+        } else {
+            // We want all nodes nested in a task to be printed horizontally
+            result += "  subgraph {\n";
+            result += "    rank=\"same\"; style=\"rounded\";\n";
+            result += node_info;
+            result += nested_nodes_info;
+            result += "  }\n";
+        }
+        return result;
+    }
+
+    inline std::string print_full_graph(std::string partial_file_name) {
+        // Generate the name of the dot file from the name of the binary
+        std::string result = partial_file_name + "_full";
+        std::string file_name = result + ".dot";
+        
+        // Open the file and start the graph
+        std::ofstream dot_file;
+        dot_file.open(file_name.c_str());
+        if(!dot_file.is_open())
+            exit(EXIT_FAILURE);
+        
+        // Compute the time average to print the nodes size accordingly
+        if(InstrumentationTGDump::_nodeSizeFunc != "constant")
+        {
+            for(std::set<Node*>::const_iterator it = _graph_nodes.begin(); it != _graph_nodes.end(); ++it) {
+                if((*it)->is_task())
+                {
+                    _min_time = std::min(_min_time, (*it)->get_total_time()); 
+                    _total_time += (*it)->get_total_time();
+                }
+            }
+            _min_diam = std::sqrt(_min_time/M_PI) * 2;
+            
+        }
+        
+        // Print the graph
+        std::map<int, int> node_to_cluster;
+        dot_file << "digraph {\n";
+            // Print attributes of the graph
+            dot_file << "  graph[compound=true];\n";
+            // Print the graph nodes
+            std::queue<Node*> worklist;
+            std::vector<Edge*> const &root_exits = _root->get_exits();
+            for (std::vector<Edge*>::const_iterator it = root_exits.begin(); it != root_exits.end(); ++it)
+                worklist.push((*it)->get_target());
+            while (!worklist.empty())
+            {
+                Node* n = worklist.front();
+                worklist.pop();
+
+                std::vector<Edge*> const &exits = n->get_exits();
+                if (n->is_printed())
+                    continue;
+                if (n->is_commutative() || n->is_concurrent())
+                {
+                    n->set_printed();
+                    for (std::vector<Edge*>::const_iterator it = exits.begin(); it != exits.end(); ++it)
+                    {
+                        worklist.push((*it)->get_target());
+                    }
+                    continue;
+                }
+
+                // Check whether there is a block of commutative
+                std::vector<Node*> out_commutatives;
+                for (std::vector<Edge*>::const_iterator it = exits.begin(); it != exits.end(); ++it) {
+                    if ((*it)->is_commutative_dep())
+                        out_commutatives.push_back((*it)->get_target());
+                }
+
+                // Print the current node and, if that is the case, its commutative nodes too
+                if (out_commutatives.empty()) {
+                    // Print the node
+                    dot_file << print_node_and_its_nested(n, /*indentation*/"  ");
+                    std::stringstream sss; sss << n->get_wd_id();
+
+                    // Print the relations with its children (or the children of the children if they are a virtual node)
+                    for (std::vector<Edge*>::const_iterator it = exits.begin(); it != exits.end(); ++it) {
+                        if ((*it)->is_nesting()) continue;
+                        Node* t = (*it)->get_target();
+
+                        if (t->is_concurrent() || t->is_commutative()) {
+                            std::vector<Edge*> const &it_exits = t->get_exits();
+                            for (std::vector<Edge*>::const_iterator itt = it_exits.begin();
+                                 itt != it_exits.end(); ++itt) {
+                               std::stringstream sst;
+                               sst << (*itt)->get_target()->get_wd_id();
+                               dot_file << "  " << sss.str() + " -> " + sst.str() + ";\n"; //TODO attributes?
+                               worklist.push((*itt)->get_target());
+                            }
+                        } else {
+                           dot_file << print_edge( *it, /*indentation*/"  " );
+                           worklist.push(t);
+                        }
+                    }
+                } else {
+                    // Since Graphviz does not allow boxes intersections and
+                    // multiple dependencies in a commutative clause may cause that situation,
+                    // we enclose all tasks in the same box and then print the dependencies individually
+                    // 1.- Get all nodes that must be in the commutative box
+                    std::vector<Node*> commutative_box;
+                    for (std::vector<Node*>::const_iterator it = out_commutatives.begin();
+                         it != out_commutatives.end(); ++it) {
+                        // Gather all siblings (parents of the out_commutative nodes)
+                        std::vector<Edge*> const &it_entries = (*it)->get_entries();
+                        for (std::vector<Edge*>::const_iterator itt = it_entries.begin();
+                             itt != it_entries.end(); ++itt) {
+                            commutative_box.push_back((*itt)->get_source());
+                        }
+                    }
+                    // 2.- Print the subgraph with all sibling nodes
+                    std::stringstream ss; ss << cluster_id++;
+                    dot_file << "  subgraph cluster_" << ss.str() << "{\n";
+                        dot_file << "    rank=\"same\"; style=\"rounded\"; label=\"Commutative\";\n";
+                        for (std::vector<Node*>::iterator it = commutative_box.begin();
+                             it != commutative_box.end(); ++it) {
+                            dot_file << print_node_and_its_nested(*it, /*indentation*/"    ");
+                        }
+                    dot_file << "  }\n";
+                    // 3.- Print the edges connecting each sibling node with its corresponding real children
+                    for (std::vector<Node*>::iterator it = commutative_box.begin();
+                         it != commutative_box.end(); ++it) {
+                        std::stringstream sss; sss << (*it)->get_wd_id();
+                        std::vector<Edge*> const &it_exits = (*it)->get_exits();
+                        for (std::vector<Edge*>::const_iterator itt = it_exits.begin();
+                             itt != it_exits.end(); ++itt) {
+                            Node* t = (*itt)->get_target();
+                            if ((*itt)->is_nesting()) continue;
+
+                            if (t->is_commutative() || t->is_concurrent())
+                            {   // If the exit is commutative|concurrent, get the exit of the exit
+                                std::vector<Edge*> const &itt_exits = t->get_exits();
+                                for (std::vector<Edge*>::const_iterator ittt = itt_exits.begin();
+                                     ittt != itt_exits.end(); ++ittt) {
+                                    std::stringstream sst; sst << (*ittt)->get_target()->get_wd_id();
+                                    dot_file << "    " << sss.str() + " -> " + sst.str() + ";\n";
+                                    // Prepare the next iteration
+                                    worklist.push((*ittt)->get_target());
+                                }
+                            } else {
+                                dot_file << print_edge( *itt, /*indentation*/"  " );
+                                // Prepare the next iteration
+                                worklist.push(t);
+                            }
+                        }
+                    }
+                }
+            }
+            
+            // Print the legends
+            dot_file << "  node [shape=plaintext];\n";
+            dot_file << print_nodes_legend();
+            dot_file << print_edges_legend();
+        dot_file << "}";
+        
+        std::cerr << "Task Dependency Graph printed to file '" << file_name << "' in DOT format" << std::endl;
+        return result;
+    }
+    
+#ifndef NANOS_INSTRUMENTATION_ENABLED
+public:
+    // constructor
+    InstrumentationTGDump() : Instrumentation(),
+                                          _graph_nodes(), _funct_id_to_decl_map(), 
+                                          _min_time(HUGE_VAL), _total_time(0.0), _min_diam(1.0)
+    {}
+    
+    // destructor
+    ~InstrumentationTGDump() {}
+
+    // low-level instrumentation interface (mandatory functions)
+    void initialize(void) {}
+    void finalize(void) {}
+    void disable(void) {}
+    void enable(void) {}
+    void addResumeTask(WorkDescriptor &w) {}
+    void addSuspendTask(WorkDescriptor &w, bool last) {}
+    void addEventList (unsigned int count, Event *events) {}
+    void threadStart(BaseThread &thread) {}
+    void threadFinish (BaseThread &thread) {}
+#else
+public:
+    
+    // constructor
+    InstrumentationTGDump() : Instrumentation(*new InstrumentationContextDisabled()),
+                                          _graph_nodes(), _funct_id_to_decl_map(), 
+                                          _min_time(HUGE_VAL), _total_time(0.0), _min_diam(1.0),
+                                          _next_tw_id(0), _next_conc_id(0)
+    {}
+    
+    // destructor
+    ~InstrumentationTGDump () {}
+
+    // low-level instrumentation interface (mandatory functions)
+    void initialize(void) 
+    {
+        _root = new Node(0, 0, Root);
+    }
+    
+    void finalize(void)
+    {
+        // So far, taskwaits have been synchronized with the tasks created previously
+        // But those tasks created after a given taskwait have not been connected to the taskwait
+        // Note: The wd of a taskwait is always a negative number!
+        // We also have to connect the root of the graph with the nodes with no parent
+        // If a node with no parent cannot be connected to a taskwait, then it has to be connected to the root
+        for (std::set<Node*>::const_iterator it = _graph_nodes.begin(); it != _graph_nodes.end(); ++it) {
+            if (!(*it)->is_previous_synchronized()) {
+                // The task has no parent, look for a taskwait|barrier suitable to be its parent
+                int64_t wd_id = (*it)->get_wd_id() - (((*it)->is_concurrent() || (*it)->is_commutative()) ? concurrent_min_id : 0);
+                Node* it_parent = (*it)->get_parent_task();
+                Node* last_taskwait_sync = NULL;
+                for (std::set<Node*>::const_iterator it2 = _graph_nodes.begin(); it2 != _graph_nodes.end(); ++it2) {
+                    if ((*it)->get_wd_id()==(*it2)->get_wd_id())                    // skip current node
+                        continue;
+                    if ((it_parent == (*it2)->get_parent_task())                    // The two nodes are in the same region
+                            && !(*it2)->is_task()                                   // The potential last sync is a taskwait|barrier|concurrent
+                            && (std::abs(wd_id) > std::abs((*it2)->get_wd_id()))    // The potential last sync was created before
+                            && !(*it)->is_connected_with(*it2)) {                   // Make sure we don't connect with our own child
+                        if ((last_taskwait_sync == NULL)
+                            || (std::abs(last_taskwait_sync->get_wd_id()) < std::abs((*it2)->get_wd_id()))) {
+                                // From all suitable previous syncs. we want the one created the latest
+                            last_taskwait_sync = *it2;
+                        }
+                    }
+                }
+                if (last_taskwait_sync != NULL) {
+                    if (std::abs(last_taskwait_sync->get_wd_id()) < (*it)->get_wd_id())
+                        Node::connect_nodes(last_taskwait_sync, *it, Synchronization);
+                } else {
+                    Node::connect_nodes(_root, *it, Synchronization);
+                }
+            }
+        }
+        
+        // Get partial name of the file that will contain the dot graph
+        std::string unique_key_name;
+        time_t t = time(NULL);
+        struct tm* tmp = localtime(&t);
+        if (tmp == NULL) {
+            std::stringstream ss; ss << getpid();
+            unique_key_name = ss.str();
+        } else {
+            char outstr[200];
+            if (strftime(outstr, sizeof(outstr), "%s", tmp) == 0) {
+                std::stringstream ss; ss << getpid();
+                unique_key_name = ss.str();
+            } else {
+                outstr[199] = '\0';
+                unique_key_name = std::string(outstr);
+            }
+        }
+        
+        std::string file_name = OS::getArg(0);
+        size_t slash_pos = file_name.find_last_of("/");
+        if(slash_pos != std::string::npos)
+            file_name = file_name.substr(slash_pos+1, file_name.size()-slash_pos);
+        file_name = file_name + "_" + unique_key_name;
+        
+        // Print the full graph
+        std::string full_dot_name = print_full_graph(file_name);
+        
+        // Generate the PDF containing the graph
+        std::string dot_to_pdf_command = "dot -Tpdf " + full_dot_name + ".dot -o " + full_dot_name + ".pdf";
+        if ( system( dot_to_pdf_command.c_str( ) ) != 0 )
+            warning( "Could not create the pdf file." );
+        std::cerr << "Task Dependency Graph printed to file '" << full_dot_name << ".pdf' in PDF format" << std::endl;
+        
+        // TODO
+        // Print the summarized graph
+//         print_summarized_graph(file_name);
+    }
+
+    void disable(void) {}
+
+    void enable(void) {}
+
+    static double get_current_time()
+    {
+        struct timeval tv;
+        gettimeofday(&tv,0);
+        return ((double) tv.tv_sec*1000000L) + ((double)tv.tv_usec);
+    }
+
+    void addResumeTask(WorkDescriptor &w)
+    {
+        Node* n = find_node_from_wd_id(w.getId());
+        if(n != NULL) {
+            n->set_last_time(get_current_time());
+        }
+    }
+
+    void addSuspendTask(WorkDescriptor &w, bool last)
+    {
+        Node* n = find_node_from_wd_id(w.getId());
+        if(n != NULL) {
+            double time = (double) get_current_time() - n->get_last_time();
+            n->add_total_time(time);
+        }
+    }
+
+    void addEventList(unsigned int count, Event *events)
+    {
+        InstrumentationDictionary *iD = getInstrumentationDictionary();
+        static const nanos_event_key_t create_wd_ptr = iD->getEventKey("create-wd-ptr");
+        static const nanos_event_key_t dependence = iD->getEventKey("dependence");
+        static const nanos_event_key_t dep_direction = iD->getEventKey("dep-direction");
+        static const nanos_event_key_t user_funct_location = iD->getEventKey("user-funct-location");
+        static const nanos_event_key_t taskwait = iD->getEventKey("taskwait");
+        static const nanos_event_key_t critical_wd_id = iD->getEventKey("critical-wd-id");
+
+        // Get the node corresponding to the wd_id calling this function
+        // This node won't exist if the calling wd corresponds to that of the master thread
+        int64_t current_wd_id = getMyWDId();
+        Node* current_parent = find_node_from_wd_id(current_wd_id);
+
+        unsigned int i;
+        for(i=0; i<count; i++) {
+            Event &e = events[i];
+            if (e.getKey() == create_wd_ptr)
+            {  // A wd is submitted => create a new node
+
+                // Get the identifier of the task function
+                WorkDescriptor *wd = (WorkDescriptor *) e.getValue();
+                int64_t funct_id = (int64_t) wd->getActiveDevice().getWorkFct();
+
+                // Get the identifier of the wd
+                int64_t wd_id = wd->getId();
+                _next_tw_id = std::min(_next_tw_id, -wd_id);
+                _next_conc_id = wd_id + 1;
+                // Create the new node
+                Node* new_node = new Node(wd_id, funct_id, TaskNode);
+                _graph_nodes_lock.acquire();
+                _graph_nodes.insert(new_node);
+                _graph_nodes_lock.release();
+
+                // Connect the task with its parent task, if exists
+                if (current_parent != NULL) {
+                    Node::connect_nodes(current_parent, new_node, Nesting);
+                }
+            }
+            else if (e.getKey() == critical_wd_id)
+            {
+               int64_t wd_id = e.getValue();
+               Node *n = find_node_from_wd_id(wd_id);
+               assert(n->is_task());
+               n->set_critical();
+            }
+            else if (e.getKey() == user_funct_location)
+            {   // A user function has been called
+                int64_t func_id = e.getValue();
+                _funct_id_to_decl_map_lock.acquire();
+                if(func_id != 0 && _funct_id_to_decl_map.find(func_id) == _funct_id_to_decl_map.end()) {
+                    // description = func_type|func_label @ file @ line @ name_type
+                    // If name_type == LABEL -> description = func_type|func_label
+                    // else if name_type == FUNCTION -> description = func_type|func_label @ file @ line
+                    std::string description = iD->getValueDescription(user_funct_location, func_id);
+                    int pos2 = description.find_first_of("@");
+                    int pos3 = description.find_last_of("@")+1;
+                    int pos4 = description.length();
+                    std::string type = description.substr(pos3, pos4-pos3);
+                    if (type == "LABEL")
+                    {
+                        // description = func_label                -> only store the label
+                        _funct_id_to_decl_map[ func_id ] = description.substr(0, pos2);
+                    }
+                    else    // type == "FUNCTION"
+                    {
+                        // description = func_type @ file @ line   -> store the whole description
+                        _funct_id_to_decl_map[ func_id ] = description.substr(0, pos3);
+                    }
+                }
+                _funct_id_to_decl_map_lock.release();
+            }
+            else if (e.getKey() == dependence)
+            {  // A dependence occurs
+
+                // Get the identifiers of the sender and the receiver
+                int64_t sender_wd_id = (int64_t) ((e.getValue() >> 32) & 0xFFFFFFFF);
+                int64_t receiver_wd_id = (int64_t) (e.getValue() & 0xFFFFFFFF);
+                
+                // Get the type of dependence
+                e = events[++i];
+                assert(e.getKey() == dep_direction);
+                DependencyType dep_type;
+                unsigned dep_value = e.getValue();
+                switch(dep_value)
+                {
+                    case 1:     dep_type = True;
+                                break;
+                    case 2:     dep_type = Anti;
+                                break;
+                    case 3:     dep_type = Output;
+                                break;
+                    case 4:     dep_type = OutConcurrent;               // wd -> concurrent
+                                receiver_wd_id += concurrent_min_id;
+                                break;
+                    case 5:     dep_type = InConcurrent;                // concurrent -> wd
+                                sender_wd_id += concurrent_min_id;
+                                break;
+                    case 6:     dep_type = OutCommutative;
+                                receiver_wd_id += concurrent_min_id;    // wd -> commutative
+                                break;
+                    case 7:     dep_type = InCommutative;
+                                sender_wd_id += concurrent_min_id;      // commutative -> wd
+                                break;
+                    case 8:     dep_type = OutAny;
+                                receiver_wd_id += concurrent_min_id;    // wd -> common
+                                break;
+                    case 9:     dep_type = InAny;
+                                sender_wd_id += concurrent_min_id;      // common -> wd
+                                break;
+                    default:    { std::cerr << "Unexpected type dependency " << dep_value << "."
+                                            << "Not printing any edge for it in the Task Dependency graph\n"
+                                            << std::endl;
+                                  return; }
+                }
+
+                // Create the relation between the sender and the receiver
+                Node* sender = find_node_from_wd_id(sender_wd_id);
+                Node* receiver = find_node_from_wd_id(receiver_wd_id);
+                if(sender == NULL || receiver == NULL) {
+                    // Compute the type for the new node
+                    NodeType nt = (((dep_type == InConcurrent) || (dep_type == OutConcurrent)) ? ConcurrentNode : CommutativeNode);
+                    
+                    // Create the new sender node, if necessary
+                    if(sender == NULL) {
+                        sender = new Node(sender_wd_id, 0, nt);
+                        _graph_nodes_lock.acquire();
+                        _graph_nodes.insert(sender);
+                        _graph_nodes_lock.release();
+                    }
+                    
+                    // Create the new receiver node, if necessary
+                    if(receiver == NULL) {
+                        receiver = new Node(receiver_wd_id, 0, nt);
+                        _graph_nodes_lock.acquire();
+                        _graph_nodes.insert(receiver);
+                        _graph_nodes_lock.release();
+                    }
+                }
+                Node::connect_nodes(sender, receiver, Dependency, dep_type);
+            }
+            else if (e.getKey() == taskwait)
+            {   // A taskwait occurs
+                // Synchronize all previous nodes created by the same task that have not been yet synchronized
+                Node* new_node = new Node(_next_tw_id, -1, TaskwaitNode);
+                --_next_tw_id;
+                // First synchronize the tasks
+                _graph_nodes_lock.acquire();
+                for(std::set<Node*>::const_iterator it = _graph_nodes.begin(); it != _graph_nodes.end(); ++it)
+                {
+                    // Synchronization nodes will be connected, if necessary, when 'finalize' is called
+                    if (!(*it)->is_next_synchronized()
+                            && ((*it)->is_task() || (*it)->is_concurrent() || (*it)->is_commutative())) {
+                        Node* parent_task = (*it)->get_parent_task();
+                        if(current_parent == parent_task) {
+                            Node::connect_nodes(*it, new_node, Synchronization);
+                        }
+                    }
+                }
+                _graph_nodes.insert(new_node);
+                _graph_nodes_lock.release();
+            }
+        }
+    }
+
+    void threadStart(BaseThread &thread) {}
+
+    void threadFinish (BaseThread &thread) {}
+
+#endif
+
+};
+
+std::string InstrumentationTGDump::_nodeSizeFunc = "log";
+
+namespace ext {
+    
+    class InstrumentationTGDumpPlugin : public Plugin {
+    public:
+        InstrumentationTGDumpPlugin () : Plugin("Instrumentation plugin which prints the graph to a dot file.", 1) {}
+        ~InstrumentationTGDumpPlugin () {}
+        
+        void config(Config &cfg) 
+        {
+            cfg.setOptionsSection("Task Dependency Graph Plugin ", "TGDump plugin specific options" );
+            cfg.registerConfigOption("node-size",  NEW Config::StringVar(InstrumentationTGDump::_nodeSizeFunc),
+                                     "Defines the size of the nodes depending on the execution time of the related task. "
+                                     "Accepted values are: constant (default), linear, log");
+            cfg.registerArgOption("node-size", "node-size");
+        }
+        
+        void init ()
+        {
+            if((InstrumentationTGDump::_nodeSizeFunc != "constant") &&
+               (InstrumentationTGDump::_nodeSizeFunc != "linear") && 
+               (InstrumentationTGDump::_nodeSizeFunc != "log"))
+            {
+                std::cerr << "Invalid node-size value \'" << InstrumentationTGDump::_nodeSizeFunc << "\'. "
+                          << "One of the following expected: \'constant\', \'linear\' and \'log\'. "
+                          << "Using default \'log\'." << std::endl;
+            }
+            sys.setInstrumentation(new InstrumentationTGDump());
+        }
+    };
+    
+} // namespace ext
+
+} // namespace nanos
+
+DECLARE_PLUGIN("instrumentation-tg-dump",nanos::ext::InstrumentationTGDumpPlugin);

--- a/src/plugins/instrumentation/tg_dump.cpp
+++ b/src/plugins/instrumentation/tg_dump.cpp
@@ -529,7 +529,7 @@ private:
             ss << print_graph_objects_json(n, indent + "  " + "  ", true) << "\n";
             ss << indent + "  " << "}";
         } else {
-            ss << indent + "  " << "\"subgraph\": null";
+            printJsonNullAttribute(indent + "  ", "subgraph", ss);
         }
 
         ss << "\n" << indent << "}";

--- a/src/plugins/instrumentation/tg_dump_utils.hpp
+++ b/src/plugins/instrumentation/tg_dump_utils.hpp
@@ -533,37 +533,27 @@ namespace nanos {
         T_value const value,
         std::ostream& os)
     {
+        os << indent << "\"" << key << "\": " << value;
+    }
+
+    // Overload for strings
+    inline void printJsonAttribute(
+        std::string const indent,
+        std::string const key,
+        std::string const value,
+        std::ostream& os)
+    {
         os << indent << "\"" << key << "\": \"" << value << "\"";
     }
 
-    // Overload for long long
+    // Overload for c strings
     inline void printJsonAttribute(
         std::string const indent,
         std::string const key,
-        long long const value,
+        char const* value,
         std::ostream& os)
     {
-        os << indent << "\"" << key << "\": " << value;
-    }
-
-    // Overload for int64_t
-    inline void printJsonAttribute(
-        std::string const indent,
-        std::string const key,
-        int64_t const value,
-        std::ostream& os)
-    {
-        os << indent << "\"" << key << "\": " << value;
-    }
-
-    // Overload for uint64_t
-    inline void printJsonAttribute(
-        std::string const indent,
-        std::string const key,
-        uint64_t const value,
-        std::ostream& os)
-    {
-        os << indent << "\"" << key << "\": " << value;
+        os << indent << "\"" << key << "\": \"" << value << "\"";
     }
 
     // Overload for boolean

--- a/src/plugins/instrumentation/tg_dump_utils.hpp
+++ b/src/plugins/instrumentation/tg_dump_utils.hpp
@@ -1,0 +1,463 @@
+/*************************************************************************************/
+/*      Copyright 2009-2018 Barcelona Supercomputing Center                          */
+/*                                                                                   */
+/*      This file is part of the NANOS++ library.                                    */
+/*                                                                                   */
+/*      NANOS++ is free software: you can redistribute it and/or modify              */
+/*      it under the terms of the GNU Lesser General Public License as published by  */
+/*      the Free Software Foundation, either version 3 of the License, or            */
+/*      (at your option) any later version.                                          */
+/*                                                                                   */
+/*      NANOS++ is distributed in the hope that it will be useful,                   */
+/*      but WITHOUT ANY WARRANTY; without even the implied warranty of               */
+/*      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                */
+/*      GNU Lesser General Public License for more details.                          */
+/*                                                                                   */
+/*      You should have received a copy of the GNU Lesser General Public License     */
+/*      along with NANOS++.  If not, see <https://www.gnu.org/licenses/>.            */
+/*************************************************************************************/
+
+#include <vector>
+#include <stdint.h>
+#include <string>
+#include "atomic.hpp"
+#include "lock.hpp"
+#include <tr1/unordered_map>
+
+namespace nanos {
+
+    struct Node;
+
+    int used_edge_types[5] = {0, 0, 0, 0, 0};
+    
+    enum DependencyType {
+        Null,
+        True,
+        Anti,
+        Output,
+        InConcurrent,
+        OutConcurrent,
+        InCommutative,
+        OutCommutative,
+        InAny,
+        OutAny
+    };
+    
+    enum EdgeKind{
+        Nesting,
+        Synchronization,
+        Dependency
+    };
+    
+    struct Edge {
+        // Class members
+        EdgeKind _kind;
+        DependencyType _dep_type;
+        Node* _source;
+        Node* _target;
+        
+        // Constructor
+        Edge( EdgeKind kind, DependencyType dep_type, Node* source, Node* target )
+            : _kind( kind ), _dep_type( dep_type ), _source( source ), _target( target )
+        {}
+        
+        Node* get_source( ) const {
+            return _source;
+        }
+        
+        Node* get_target( ) const {
+            return _target;
+        }
+        
+        EdgeKind get_kind( ) const {
+            return _kind;
+        }
+        
+        bool is_nesting( ) const {
+            return _kind == Nesting;
+        }
+        
+        bool is_synchronization( ) const {
+            return _kind == Synchronization;
+        }
+        
+        bool is_dependency( ) const {
+            return _kind == Dependency;
+        }
+        
+        DependencyType get_dependency_type( ) const {
+            return _dep_type;
+        }
+        
+        bool is_true_dependency( ) const {
+            return ( ( _kind == Dependency ) && 
+                     ( ( _dep_type == True ) || ( _dep_type == InConcurrent ) || ( _dep_type == InCommutative ) || ( _dep_type == InAny ) ) );
+        }
+        
+        bool is_anti_dependency( ) const {
+            return ( ( _kind == Dependency ) && ( _dep_type == Anti ) );
+        }
+        
+        bool is_output_dependency( ) const {
+            return ( ( _kind == Dependency ) && 
+                     ( ( _dep_type == Output ) || ( _dep_type == OutConcurrent ) || ( _dep_type == OutCommutative ) || ( _dep_type == OutAny ) ) );
+        }
+        
+        bool is_concurrent_dep( ) const {
+            return ( ( _kind == Dependency ) && 
+                     ( ( _dep_type == InConcurrent ) || ( _dep_type == OutConcurrent ) ) );
+        }
+        
+        bool is_commutative_dep( ) const {
+            return ( ( _kind == Dependency ) && 
+                     ( ( _dep_type == InCommutative ) || ( _dep_type == OutCommutative ) ) );
+        }
+        
+        bool is_any_dep( ) const {
+            return ( ( _kind == Dependency ) && 
+                     ( ( _dep_type == InAny ) || ( _dep_type == OutAny ) ) );
+        }
+    };
+    
+    enum NodeType {
+        Root,
+        BarrierNode,
+        ConcurrentNode,
+        CommutativeNode,
+        TaskNode,
+        TaskwaitNode
+    };
+    
+    struct Node {
+        // Class members
+        int64_t _wd_id;
+        int64_t _func_id;
+        NodeType _type;
+        std::vector<Edge*> _entry_edges;
+        std::vector<Edge*> _exit_edges;
+        double _total_time;
+        double _last_time;
+        Lock _entry_lock;
+        Lock _exit_lock;
+        
+        bool _printed;
+        bool _critical;
+ 
+        // Constructor
+        Node( int64_t wd_id, int64_t func_id, NodeType type )
+            : _wd_id( wd_id ), _func_id( func_id ), _type( type ),
+              _entry_edges( ), _exit_edges( ), 
+              _total_time( 0.0 ), _last_time( 0.0 ), _printed( false ), _critical( false )
+        {}
+        
+        int64_t get_wd_id( ) const {
+            return _wd_id;
+        }
+        
+        int64_t get_funct_id( ) const {
+            return _func_id;
+        }
+        
+        std::vector<Edge*> const &get_entries( ) {
+            return _entry_edges;
+        }
+        
+        std::vector<Edge*> const &get_exits( ) {
+            return _exit_edges;
+        }
+        
+        double get_last_time( ) const {
+            return _last_time;
+        }
+        
+        void set_last_time( double time ) {
+            _last_time = time;
+        }
+        
+        double get_total_time( ) const {
+            return _total_time;
+        }
+        
+        void add_total_time( double time ) {
+            _total_time += time;
+        }
+        
+        Node* get_parent_task( ) {
+            Node* res = NULL;
+            _entry_lock.acquire();
+            for( std::vector<Edge*>::const_iterator it = _entry_edges.begin( ); it != _entry_edges.end( ); ++it ) {
+                if( (*it)->is_nesting( ) ) {
+                    res = (*it)->get_source( );
+                    break;
+                }
+            }
+            _entry_lock.release();
+            return res;
+        }
+        
+        //called in finalize, and connect_nodes (with _exit_lock acquired)
+        bool is_connected_with( Node* target ) const {
+            bool res = false;
+            for( std::vector<Edge*>::const_iterator it = _exit_edges.begin( ); it != _exit_edges.end( ); ++it ) {
+                if( (*it)->get_target( ) == target ) {
+                    res = true;
+                    break;
+                }
+            }
+            return res;
+        }
+       
+        //called in connect_nodes (with _exit_lock acquired)
+        Edge* get_connection( Node* target ) const {
+            Edge* result = NULL;
+            for( std::vector<Edge*>::const_iterator it = _exit_edges.begin( ); it != _exit_edges.end( ); ++it ) {
+                if( (*it)->get_target( ) == target ) {
+                    result = *it;
+                    break;
+                }
+            }
+            return result;
+        }
+        
+        //only called in finalize
+        bool is_previous_synchronized( ) const {
+            bool res = false;
+            for( std::vector<Edge*>::const_iterator it = _entry_edges.begin( ); it != _entry_edges.end( ); ++it ) {
+                if( (*it)->is_dependency( ) || (*it)->is_synchronization( ) ) {
+                    res = true;
+                    break;
+                }
+            }
+            return res;
+        }
+        
+        bool is_next_synchronized( ) {
+            bool res = false;
+            _exit_lock.acquire();
+            for( std::vector<Edge*>::const_iterator it = _exit_edges.begin( ); it != _exit_edges.end( ); ++it ) {
+                if( (*it)->is_dependency( ) || (*it)->is_synchronization( ) ) {
+                    res = true;
+                    break;
+                }
+            }
+            _exit_lock.release();
+            return res;
+        }
+        
+        //! Only connect the nodes if they are not previously connected or 
+        //! the new type of connection is different from the existing one
+        static void connect_nodes( Node* source, Node* target, EdgeKind kind, DependencyType dep_type = Null ) {
+            source->_exit_lock.acquire();
+            if( !source->is_connected_with( target ) || 
+                ( source->get_connection( target )->get_kind( ) != kind ) ||
+                ( source->get_connection( target )->get_dependency_type( ) != dep_type ) ) {
+                Edge* new_edge = new Edge( kind, dep_type, source, target );
+                source->_exit_edges.push_back( new_edge );
+                target->_entry_lock.acquire();
+                target->_entry_edges.push_back( new_edge );
+                target->_entry_lock.release();
+
+                // store the edge type as used
+                switch (kind)
+                {
+                    case Nesting :          used_edge_types[3] = 1; break;
+                    case Synchronization :  used_edge_types[0] = 1; break;
+                    case Dependency :       {
+                                                switch (dep_type)
+                                                {
+                                                    case True:      used_edge_types[0] = 1; break;
+                                                    case Anti:      used_edge_types[1] = 1; break;
+                                                    case Output:    used_edge_types[2] = 1; break;
+                                                    default:        break;
+                                                };
+                                                break;
+                                            };
+                    default:                break;
+                };
+                if (source->is_critical() && target->is_critical())
+                {
+                    used_edge_types[4] = 1;
+                }
+            }
+            source->_exit_lock.release();
+        }
+        
+        bool is_task( ) const {
+            return _type == TaskNode;
+        }
+
+        bool is_taskwait( ) const {
+            return _type == TaskwaitNode;
+        }
+        
+        bool is_barrier( ) const {
+            return _type == BarrierNode;
+        }
+        
+        bool is_concurrent( ) const {
+            return _type == ConcurrentNode;
+        }
+        
+        bool is_commutative( ) const {
+            return _type == CommutativeNode;
+        }
+        
+        bool is_printed( ) const {
+            return _printed;
+        }
+        
+        void set_printed( ) {
+            _printed = true;
+        }
+
+        bool is_critical( ) {
+           return _critical;
+        }
+
+        void set_critical( ) {
+           _critical = true;
+        }
+    };
+
+    std::string node_colors[] = {
+        "aliceblue", "antiquewhite", "antiquewhite1", "antiquewhite2", "antiquewhite3",
+        "antiquewhite4", "aquamarine", "aquamarine1", "aquamarine2", "aquamarine3",
+        "aquamarine4", "azure", "azure1", "azure2", "azure3",
+        "azure4", "beige", "bisque", "bisque1", "bisque2",
+        "bisque3", "bisque4", "black", "blanchedalmond", "blue",
+        "blue1", "blue2", "blue3", "blue4", "blueviolet",
+        "brown", "brown1", "brown2", "brown3", "brown4",
+        "burlywood", "burlywood1", "burlywood2", "burlywood3", "burlywood4",
+        "cadetblue", "cadetblue1", "cadetblue2", "cadetblue3", "cadetblue4",
+        "chartreuse", "chartreuse1", "chartreuse2", "chartreuse3", "chartreuse4",
+        "chocolate", "chocolate1", "chocolate2", "chocolate3", "chocolate4",
+        "coral", "coral1", "coral2", "coral3", "coral4",
+        "cornflowerblue", "cornsilk", "cornsilk1", "cornsilk2", "cornsilk3",
+        "cornsilk4", "crimson", "cyan", "cyan1", "cyan2",
+        "cyan3", "cyan4", "darkgoldenrod", "darkgoldenrod1", "darkgoldenrod2",
+        "darkgoldenrod3", "darkgoldenrod4", "darkgreen", "darkkhaki", "darkolivegreen",
+        "darkolivegreen1", "darkolivegreen2", "darkolivegreen3", "darkolivegreen4", "darkorange",
+        "darkorange1", "darkorange2", "darkorange3", "darkorange4", "darkorchid",
+        "darkorchid1", "darkorchid2", "darkorchid3", "darkorchid4", "darksalmon",
+        "darkseagreen", "darkseagreen1", "darkseagreen2", "darkseagreen3", "darkseagreen4",
+        "darkslateblue", "darkslategray", "darkslategray1", "darkslategray2", "darkslategray3",
+        "darkslategray4", "darkslategrey", "darkturquoise", "darkviolet", "deeppink",
+        "deeppink1", "deeppink2", "deeppink3", "deeppink4", "deepskyblue",
+        "deepskyblue1", "deepskyblue2", "deepskyblue3", "deepskyblue4", "dimgray",
+        "dimgrey", "dodgerblue", "dodgerblue1", "dodgerblue2", "dodgerblue3",
+        "dodgerblue4", "firebrick", "firebrick1", "firebrick2", "firebrick3",
+        "firebrick4", "floralwhite", "forestgreen", "gainsboro", "ghostwhite",
+        "gold", "gold1", "gold2", "gold3", "gold4",
+        "goldenrod", "goldenrod1", "goldenrod2", "goldenrod3", "goldenrod4",
+        "gray", "gray0", "gray1", "gray10", "gray100",
+        "gray11", "gray12", "gray13", "gray14", "gray15",
+        "gray16", "gray17", "gray18", "gray19", "gray2",
+        "gray20", "gray21", "gray22", "gray23", "gray24",
+        "gray25", "gray26", "gray27", "gray28", "gray29",
+        "gray3", "gray30", "gray31", "gray32", "gray33",
+        "gray34", "gray35", "gray36", "gray37", "gray38",
+        "gray39", "gray4", "gray40", "gray41", "gray42",
+        "gray43", "gray44", "gray45", "gray46", "gray47",
+        "gray48", "gray49", "gray5", "gray50", "gray51",
+        "gray52", "gray53", "gray54", "gray55", "gray56",
+        "gray57", "gray58", "gray59", "gray6", "gray60",
+        "gray61", "gray62", "gray63", "gray64", "gray65",
+        "gray66", "gray67", "gray68", "gray69", "gray7",
+        "gray70", "gray71", "gray72", "gray73", "gray74",
+        "gray75", "gray76", "gray77", "gray78", "gray79",
+        "gray8", "gray80", "gray81", "gray82", "gray83",
+        "gray84", "gray85", "gray86", "gray87", "gray88",
+        "gray89", "gray9 ", "gray90", "gray91", "gray92",
+        "gray93", "gray94", "gray95", "gray96", "gray97",
+        "gray98", "gray99", "green", "green1", "green2",
+        "green3", "green4", "greenyellow", "grey", "grey0",
+        "grey1", "grey10", "grey100", "grey11", "grey12",
+        "grey13", "grey14", "grey15", "grey16", "grey17",
+        "grey18", "grey19", "grey2", "grey20", "grey21",
+        "grey22", "grey23", "grey24", "grey25", "grey26",
+        "grey27", "grey28", "grey29", "grey3", "grey30",
+        "grey31", "grey32", "grey33", "grey34", "grey35",
+        "grey36", "grey37", "grey38", "grey39", "grey4",
+        "grey40", "grey41", "grey42", "grey43", "grey44",
+        "grey45", "grey46", "grey47", "grey48", "grey49",
+        "grey5", "grey50", "grey51", "grey52", "grey53",
+        "grey54", "grey55", "grey56", "grey57", "grey58",
+        "grey59", "grey6", "grey60", "grey61", "grey62",
+        "grey63", "grey64", "grey65", "grey66", "grey67",
+        "grey68", "grey69", "grey7", "grey70", "grey71",
+        "grey72", "grey73", "grey74", "grey75", "grey76",
+        "grey77", "grey78", "grey79", "grey8", "grey80",
+        "grey81", "grey82", "grey83", "grey84", "grey85",
+        "grey86", "grey87", "grey88", "grey89", "grey9",
+        "grey90", "grey91", "grey92", "grey93", "grey94",
+        "grey95", "grey96", "grey97", "grey98", "grey99",
+        "honeydew", "honeydew1", "honeydew2", "honeydew3", "honeydew4",
+        "hotpink", "hotpink1", "hotpink2", "hotpink3", "hotpink4",
+        "indianred", "indianred1", "indianred2", "indianred3", "indianred4",
+        "indigo", "invis", "ivory", "ivory1", "ivory2",
+        "ivory3", "ivory4", "khaki", "khaki1", "khaki2",
+        "khaki3", "khaki4", "lavender", "lavenderblush", "lavenderblush1",
+        "lavenderblush2", "lavenderblush3", "lavenderblush4", "lawngreen", "lemonchiffon",
+        "lemonchiffon1", "lemonchiffon2", "lemonchiffon3", "lemonchiffon4", "lightblue",
+        "lightblue1", "lightblue2", "lightblue3", "lightblue4", "lightcoral",
+        "lightcyan", "lightcyan1", "lightcyan2", "lightcyan3", "lightcyan4",
+        "lightgoldenrod", "lightgoldenrod1", "lightgoldenrod2", "lightgoldenrod3", "lightgoldenrod4",
+        "lightgoldenrodyellow", "lightgray", "lightgrey", "lightpink", "lightpink1",
+        "lightpink2", "lightpink3", "lightpink4", "lightsalmon", "lightsalmon1",
+        "lightsalmon2", "lightsalmon3", "lightsalmon4", "lightseagreen", "lightskyblue",
+        "lightskyblue1", "lightskyblue2", "lightskyblue3", "lightskyblue4", "lightslateblue",
+        "lightslategray", "lightslategrey", "lightsteelblue", "lightsteelblue1", "lightsteelblue2",
+        "lightsteelblue3", "lightsteelblue4", "lightyellow", "lightyellow1", "lightyellow2",
+        "lightyellow3", "lightyellow4", "limegreen", "linen", "magenta",
+        "magenta1", "magenta2", "magenta3", "magenta4", "maroon",
+        "maroon1", "maroon2", "maroon3", "maroon4", "mediumaquamarine",
+        "mediumblue", "mediumorchid", "mediumorchid1", "mediumorchid2", "mediumorchid3",
+        "mediumorchid4", "mediumpurple", "mediumpurple1", "mediumpurple2", "mediumpurple3",
+        "mediumpurple4", "mediumseagreen", "mediumslateblue", "mediumspringgreen", "mediumturquoise",
+        "mediumvioletred", "midnightblue", "mintcream", "mistyrose", "mistyrose1",
+        "mistyrose2", "mistyrose3", "mistyrose4", "moccasin", "navajowhite",
+        "navajowhite1", "navajowhite2", "navajowhite3", "navajowhite4", "navy",
+        "navyblue", "none", "oldlace", "olivedrab", "olivedrab1",
+        "olivedrab2", "olivedrab3", "olivedrab4", "orange", "orange1",
+        "orange2", "orange3", "orange4", "orangered", "orangered1",
+        "orangered2", "orangered3", "orangered4", "orchid", "orchid1",
+        "orchid2", "orchid3", "orchid4", "palegoldenrod", "palegreen",
+        "palegreen1", "palegreen2", "palegreen3", "palegreen4", "paleturquoise",
+        "paleturquoise1", "paleturquoise2", "paleturquoise3", "paleturquoise4", "palevioletred",
+        "palevioletred1", "palevioletred2", "palevioletred3", "palevioletred4", "papayawhip",
+        "peachpuff", "peachpuff1", "peachpuff2", "peachpuff3", "peachpuff4",
+        "peru", "pink", "pink1", "pink2", "pink3",
+        "pink4", "plum", "plum1", "plum2", "plum3",
+        "plum4", "powderblue", "purple", "purple1", "purple2",
+        "purple3", "purple4", "red", "red1", "red2",
+        "red3", "red4", "rosybrown", "rosybrown1", "rosybrown2",
+        "rosybrown3", "rosybrown4", "royalblue", "royalblue1", "royalblue2",
+        "royalblue3", "royalblue4", "saddlebrown", "salmon", "salmon1",
+        "salmon2", "salmon3", "salmon4", "sandybrown", "seagreen",
+        "seagreen1", "seagreen2", "seagreen3", "seagreen4", "seashell",
+        "seashell1", "seashell2", "seashell3", "seashell4", "sienna",
+        "sienna1", "sienna2", "sienna3", "sienna4", "skyblue",
+        "skyblue1", "skyblue2", "skyblue3", "skyblue4", "slateblue",
+        "slateblue1", "slateblue2", "slateblue3", "slateblue4", "slategray",
+        "slategray1", "slategray2", "slategray3", "slategray4", "slategrey",
+        "snow", "snow1", "snow2", "snow3", "snow4",
+        "springgreen", "springgreen1", "springgreen2", "springgreen3", "springgreen4",
+        "steelblue", "steelblue1", "steelblue2", "steelblue3", "steelblue4",
+        "tan", "tan1", "tan2", "tan3", "tan4",
+        "thistle", "thistle1", "thistle2", "thistle3", "thistle4",
+        "tomato", "tomato1", "tomato2", "tomato3", "tomato4",
+        "transparent", "turquoise", "turquoise1", "turquoise2", "turquoise3",
+        "turquoise4", "violet", "violetred", "violetred1", "violetred2",
+        "violetred3", "violetred4", "wheat", "wheat1", "wheat2",
+        "wheat3", "wheat4", "white", "whitesmoke", "yellow",
+        "yellow1", "yellow2", "yellow3", "yellow4", "yellowgreen"
+    };
+
+    inline std::string &wd_to_color_hash(std::string description)
+    {
+        int const node_color_count = sizeof(node_colors) / sizeof(node_colors[0]);
+        std::tr1::hash<std::string> hash_fn;
+        return node_colors[ hash_fn(description) % node_color_count ];
+    }
+
+} // namespace nanos

--- a/src/plugins/instrumentation/tg_dump_utils.hpp
+++ b/src/plugins/instrumentation/tg_dump_utils.hpp
@@ -244,6 +244,7 @@ namespace nanos {
             std::vector<Edge*> c = source->get_connections(target);
             for (std::vector<Edge*>::iterator it = c.begin(); it != c.end(); ++it) {
                 if(*(*it) == *new_edge) {
+                    source->_exit_lock.release();
                     return;
                 }
             }

--- a/src/plugins/instrumentation/tg_dump_utils.hpp
+++ b/src/plugins/instrumentation/tg_dump_utils.hpp
@@ -55,10 +55,15 @@ namespace nanos {
         DependencyType _dep_type;
         Node* _source;
         Node* _target;
+        uint64_t _data_size;
         
         // Constructor
-        Edge( EdgeKind kind, DependencyType dep_type, Node* source, Node* target )
-            : _kind( kind ), _dep_type( dep_type ), _source( source ), _target( target )
+        Edge(EdgeKind kind, DependencyType dep_type, Node* source, Node* target, uint64_t data_size) : 
+            _kind(kind), 
+            _dep_type(dep_type),
+            _source(source), 
+            _target(target), 
+            _data_size(data_size)
         {}
         
         Node* get_source( ) const {
@@ -75,6 +80,10 @@ namespace nanos {
         
         bool is_nesting( ) const {
             return _kind == Nesting;
+        }
+        
+        uint64_t get_data_size( ) {
+           return _data_size;
         }
         
         bool is_synchronization( ) const {
@@ -251,7 +260,7 @@ namespace nanos {
             if( !source->is_connected_with( target ) || 
                 ( source->get_connection( target )->get_kind( ) != kind ) ||
                 ( source->get_connection( target )->get_dependency_type( ) != dep_type ) ) {
-                Edge* new_edge = new Edge( kind, dep_type, source, target );
+                Edge* new_edge = new Edge( kind, dep_type, source, target, 0 );
                 source->_exit_edges.push_back( new_edge );
                 target->_entry_lock.acquire();
                 target->_entry_edges.push_back( new_edge );

--- a/src/plugins/instrumentation/tg_dump_utils.hpp
+++ b/src/plugins/instrumentation/tg_dump_utils.hpp
@@ -221,12 +221,12 @@ namespace nanos {
 
         //! Only connect the nodes if they are not previously connected or
         //! the new type of connection is different from the existing one
-        static void connect_nodes( Node* source, Node* target, EdgeKind kind, DependencyType dep_type = Null ) {
+        static void connect_nodes( Node* source, Node* target, EdgeKind kind, uint64_t data_size, DependencyType dep_type = Null ) {
             source->_exit_lock.acquire();
             if( !source->is_connected_with( target ) ||
                 ( source->get_connection( target )->get_kind( ) != kind ) ||
                 ( source->get_connection( target )->get_dependency_type( ) != dep_type ) ) {
-                Edge* new_edge = new Edge( kind, dep_type, source, target, 0 );
+                Edge* new_edge = new Edge( kind, dep_type, source, target, data_size );
                 source->_exit_edges.push_back( new_edge );
                 target->_entry_lock.acquire();
                 target->_entry_edges.push_back( new_edge );

--- a/src/plugins/instrumentation/tg_dump_utils.hpp
+++ b/src/plugins/instrumentation/tg_dump_utils.hpp
@@ -578,6 +578,14 @@ namespace nanos {
         os << std::noboolalpha;
     }
 
+    inline void printJsonNullAttribute(
+        std::string const indent,
+        std::string const key,
+        std::ostream& os)
+    {
+        os << indent << "\"" << key << "\": null";
+    }
+
     template<class T_value>
     inline void printJsonAttributeArray(
         std::string const indent,

--- a/src/plugins/instrumentation/tg_dump_utils.hpp
+++ b/src/plugins/instrumentation/tg_dump_utils.hpp
@@ -139,7 +139,7 @@ namespace nanos {
 
         bool _printed;
         bool _critical;
-        
+
         int _papi_event_set;
         std::vector<std::pair<int, long long> > _papi_counters;   // first - event id, second - counter value
 
@@ -301,15 +301,15 @@ namespace nanos {
         }
 
         void start_operation_counters(std::vector<int>& papi_event_codes)
-        {   
+        {
             int rc;
-            
+
             if(_papi_event_set == PAPI_NULL) {
                 if((rc = PAPI_create_eventset(&_papi_event_set)) != PAPI_OK) {
                     std::cerr << "Failed to create node event set. ";
                     std::cerr << "Papi error: (" << rc << ") - " << PAPI_strerror(rc) << "\n";
                 }
-                
+
                 std::vector<int>::iterator it;
                 for(it = papi_event_codes.begin(); it != papi_event_codes.end(); ++it) {
                     if((rc = PAPI_add_event(_papi_event_set, *it)) != PAPI_OK) {
@@ -320,17 +320,17 @@ namespace nanos {
                     }
                 }
             }
-            
+
             if((rc = PAPI_start(_papi_event_set)) != PAPI_OK) {
                 std::cerr << "Failed to start node performance counters. ";
                 std::cerr << "Papi error: (" << rc << ") - " << PAPI_strerror(rc) << "\n";
             }
         }
-        
+
         void suspend_operation_counters(bool const last) {
             int rc;
             long long counter_values[_papi_counters.size()];
-         
+
             if((rc = PAPI_stop(_papi_event_set, counter_values)) != PAPI_OK) {
                 std::cerr << "Failed to get node performance counters. ";
                 std::cerr << "Papi error: (" << rc << ") - " << PAPI_strerror(rc) << "\n";
@@ -339,7 +339,7 @@ namespace nanos {
                     _papi_counters[i].second += counter_values[i];
                 }
             }
-            
+
             if(last) {
                 if((rc = PAPI_cleanup_eventset(_papi_event_set)) != PAPI_OK) {
                     std::cerr << "Failed to clean up node event set. ";
@@ -492,17 +492,17 @@ namespace nanos {
         std::tr1::hash<std::string> hash_fn;
         return node_colors[ hash_fn(description) % node_color_count ];
     }
-    
+
     inline std::string formatSize(long long bytes) {
         std::string units[] = {"B","kB","MB","GB","TB","PB","EB","YB"};
         int const max_units = sizeof(units) / sizeof(units[0]);
-        
+
         double size = bytes;
         int i;
         for(i = 0; i < max_units && size > 1024; i++) {
             size /= 1024;
         }
-        
+
         std::stringstream ss;
         ss.precision(3);
         ss << size << units[i];
@@ -513,19 +513,19 @@ namespace nanos {
         std::string units[] = {"us","ms","S","M","H","D"};
         int const unit_multiples[] = {1000, 1000, 60, 60, 24};
         int const max_units = sizeof(units) / sizeof(units[0]);
-        
+
         double time = us;
         int i;
         for(i = 0; i < max_units && time > unit_multiples[i]; i++) {
             time /= unit_multiples[i];
         }
-        
+
         std::stringstream ss;
         ss.precision(3);
         ss << time << units[i];
         return ss.str();
     }
-    
+
     template<class T_value>
     inline void printJsonAttribute(
         std::string const indent,
@@ -535,7 +535,7 @@ namespace nanos {
     {
         os << indent << "\"" << key << "\": \"" << value << "\"";
     }
-    
+
     // Overload for long long
     inline void printJsonAttribute(
         std::string const indent,
@@ -545,7 +545,7 @@ namespace nanos {
     {
         os << indent << "\"" << key << "\": " << value;
     }
-    
+
     // Overload for int64_t
     inline void printJsonAttribute(
         std::string const indent,
@@ -555,7 +555,7 @@ namespace nanos {
     {
         os << indent << "\"" << key << "\": " << value;
     }
-    
+
     // Overload for uint64_t
     inline void printJsonAttribute(
         std::string const indent,
@@ -565,7 +565,7 @@ namespace nanos {
     {
         os << indent << "\"" << key << "\": " << value;
     }
-    
+
     // Overload for boolean
     inline void printJsonAttribute(
         std::string const indent,
@@ -577,23 +577,23 @@ namespace nanos {
         os << indent << "\"" << key << "\": " << value;
         os << std::noboolalpha;
     }
-    
+
     template<class T_value>
     inline void printJsonAttributeArray(
         std::string const indent,
         std::string const name,
         std::vector<std::pair<std::string, T_value> > const data,
         std::ostream& os)
-    {   
+    {
         os << indent << "\"" << name << "\": {\n";
-        
+
         for(unsigned i = 0; i < data.size(); i++) {
             printJsonAttribute(indent + "  ", data[i].first, data[i].second, os);
             if(i < data.size() - 1) {
                 os << ",\n";
             }
         }
-        
+
         os << "\n" << indent << "}";
     }
 

--- a/src/plugins/instrumentation/tg_dump_utils.hpp
+++ b/src/plugins/instrumentation/tg_dump_utils.hpp
@@ -492,5 +492,38 @@ namespace nanos {
         std::tr1::hash<std::string> hash_fn;
         return node_colors[ hash_fn(description) % node_color_count ];
     }
+    
+    inline std::string formatSize(long long bytes) {
+        std::string units[] = {"B","kB","MB","GB","TB","PB","EB","YB"};
+        int const max_units = sizeof(units) / sizeof(units[0]);
+        
+        double size = bytes;
+        int i;
+        for(i = 0; i < max_units && size > 1024; i++) {
+            size /= 1024;
+        }
+        
+        std::stringstream ss;
+        ss.precision(3);
+        ss << size << units[i];
+        return ss.str();
+    }
+
+    inline std::string formatTime(long long us) {
+        std::string units[] = {"us","ms","S","M","H","D"};
+        int const unit_multiples[] = {1000, 1000, 60, 60, 24};
+        int const max_units = sizeof(units) / sizeof(units[0]);
+        
+        double time = us;
+        int i;
+        for(i = 0; i < max_units && time > unit_multiples[i]; i++) {
+            time /= unit_multiples[i];
+        }
+        
+        std::stringstream ss;
+        ss.precision(3);
+        ss << time << units[i];
+        return ss.str();
+    }
 
 } // namespace nanos

--- a/src/plugins/instrumentation/tg_dump_utils.hpp
+++ b/src/plugins/instrumentation/tg_dump_utils.hpp
@@ -649,9 +649,9 @@ namespace nanos {
 
         void to_json(std::string const indent, std::ostream& os) {
             os << indent << "{\n";
-            printJsonAttribute(indent + "  ", "input", _is_input, os);
+            printJsonAttribute(indent + "  ", "is_input", _is_input, os);
             os << ",\n";
-            printJsonAttribute(indent + "  ", "output", _is_output, os);
+            printJsonAttribute(indent + "  ", "is_output", _is_output, os);
             os << ",\n";
             printJsonAttribute(indent + "  ", "start_address", (uint64_t)_start_address, os);
             os << ",\n";

--- a/src/plugins/instrumentation/tg_dump_utils.hpp
+++ b/src/plugins/instrumentation/tg_dump_utils.hpp
@@ -66,36 +66,22 @@ namespace nanos {
             _data_size(data_size)
         {}
         
-        Node* get_source( ) const {
-            return _source;
+        Node* get_source() const {return _source;}
+        Node* get_target() const {return _target;}
+        EdgeKind get_kind() const {return _kind;}
+        DependencyType get_dependency_type() const {return _dep_type;}
+        uint64_t get_data_size() const {return _data_size;}
+        
+        bool is_nesting() const {
+           return _kind == Nesting;
         }
         
-        Node* get_target( ) const {
-            return _target;
+        bool is_synchronization() const {
+           return _kind == Synchronization;
         }
         
-        EdgeKind get_kind( ) const {
-            return _kind;
-        }
-        
-        bool is_nesting( ) const {
-            return _kind == Nesting;
-        }
-        
-        uint64_t get_data_size( ) {
-           return _data_size;
-        }
-        
-        bool is_synchronization( ) const {
-            return _kind == Synchronization;
-        }
-        
-        bool is_dependency( ) const {
-            return _kind == Dependency;
-        }
-        
-        DependencyType get_dependency_type( ) const {
-            return _dep_type;
+        bool is_dependency() const {
+           return _kind == Dependency;
         }
         
         bool is_true_dependency( ) const {
@@ -159,36 +145,16 @@ namespace nanos {
               _total_time( 0.0 ), _last_time( 0.0 ), _printed( false ), _critical( false )
         {}
         
-        int64_t get_wd_id( ) const {
-            return _wd_id;
-        }
-        
-        int64_t get_funct_id( ) const {
-            return _func_id;
-        }
-        
-        std::vector<Edge*> const &get_entries( ) {
-            return _entry_edges;
-        }
-        
-        std::vector<Edge*> const &get_exits( ) {
-            return _exit_edges;
-        }
-        
-        double get_last_time( ) const {
-            return _last_time;
-        }
-        
-        void set_last_time( double time ) {
-            _last_time = time;
-        }
-        
-        double get_total_time( ) const {
-            return _total_time;
-        }
+        int64_t get_wd_id() const {return _wd_id;}
+        int64_t get_funct_id() const {return _func_id;}
+        std::vector<Edge*> const &get_entries() {return _entry_edges;}
+        std::vector<Edge*> const &get_exits() {return _exit_edges;}
+        double get_last_time() const {return _last_time;}
+        void set_last_time(double time) {_last_time = time;}
+        double get_total_time() const {return _total_time;}
         
         void add_total_time( double time ) {
-            _total_time += time;
+           _total_time += time;
         }
         
         Node* get_parent_task( ) {

--- a/src/plugins/instrumentation/tg_dump_utils.hpp
+++ b/src/plugins/instrumentation/tg_dump_utils.hpp
@@ -525,5 +525,76 @@ namespace nanos {
         ss << time << units[i];
         return ss.str();
     }
+    
+    template<class T_value>
+    inline void printJsonAttribute(
+        std::string const indent,
+        std::string const key,
+        T_value const value,
+        std::ostream& os)
+    {
+        os << indent << "\"" << key << "\": \"" << value << "\"";
+    }
+    
+    // Overload for long long
+    inline void printJsonAttribute(
+        std::string const indent,
+        std::string const key,
+        long long const value,
+        std::ostream& os)
+    {
+        os << indent << "\"" << key << "\": " << value;
+    }
+    
+    // Overload for int64_t
+    inline void printJsonAttribute(
+        std::string const indent,
+        std::string const key,
+        int64_t const value,
+        std::ostream& os)
+    {
+        os << indent << "\"" << key << "\": " << value;
+    }
+    
+    // Overload for uint64_t
+    inline void printJsonAttribute(
+        std::string const indent,
+        std::string const key,
+        uint64_t const value,
+        std::ostream& os)
+    {
+        os << indent << "\"" << key << "\": " << value;
+    }
+    
+    // Overload for boolean
+    inline void printJsonAttribute(
+        std::string const indent,
+        std::string const key,
+        bool const value,
+        std::ostream& os)
+    {
+        os << std::boolalpha;
+        os << indent << "\"" << key << "\": " << value;
+        os << std::noboolalpha;
+    }
+    
+    template<class T_value>
+    inline void printJsonAttributeArray(
+        std::string const indent,
+        std::string const name,
+        std::vector<std::pair<std::string, T_value> > const data,
+        std::ostream& os)
+    {   
+        os << indent << "\"" << name << "\": {\n";
+        
+        for(unsigned i = 0; i < data.size(); i++) {
+            printJsonAttribute(indent + "  ", data[i].first, data[i].second, os);
+            if(i < data.size() - 1) {
+                os << ",\n";
+            }
+        }
+        
+        os << "\n" << indent << "}";
+    }
 
 } // namespace nanos

--- a/src/support/depsregion.hpp
+++ b/src/support/depsregion.hpp
@@ -50,6 +50,9 @@ inline bool DepsRegion::overlap ( const BaseDependency &obj ) const
  
 inline bool DepsRegion::operator< ( const DepsRegion &obj ) const
 {
+   if(_address == obj._address) {
+      return _endAddress < obj._endAddress;
+   }
    return _address < obj._address;
 }
 

--- a/src/support/depsregion.hpp
+++ b/src/support/depsregion.hpp
@@ -56,7 +56,7 @@ inline bool DepsRegion::operator< ( const DepsRegion &obj ) const
    return _address < obj._address;
 }
 
-inline std::pair<void*, void*> DepsRegion::getOverlapRange ( const DepsRegion &other ) const
+inline std::pair<void*, void*> DepsRegion::computeOverlap ( const DepsRegion &other ) const
 {
    void* overlap_start = std::max((void*)other._address, (void*)_address);
    void* overlap_end = std::min((void*)other._endAddress, (void*)_endAddress);

--- a/src/support/depsregion.hpp
+++ b/src/support/depsregion.hpp
@@ -56,6 +56,13 @@ inline bool DepsRegion::operator< ( const DepsRegion &obj ) const
    return _address < obj._address;
 }
 
+inline uint64_t DepsRegion::overlapSize ( const DepsRegion &other ) const
+{
+   TargetType overlap_start = std::max(other._address, _address);
+   TargetType overlap_end = std::min(other._endAddress, _endAddress);
+   return (uint64_t)overlap_end - (uint64_t)overlap_start;
+}
+
 inline BaseDependency* DepsRegion::clone() const
 {
    return new DepsRegion( _address, _endAddress, _trackable );

--- a/src/support/depsregion.hpp
+++ b/src/support/depsregion.hpp
@@ -56,12 +56,12 @@ inline bool DepsRegion::operator< ( const DepsRegion &obj ) const
    return _address < obj._address;
 }
 
-inline uint64_t DepsRegion::overlapSize ( const DepsRegion &other ) const
+inline std::pair<void*, void*> DepsRegion::getOverlapRange ( const DepsRegion &other ) const
 {
-   TargetType overlap_start = std::max(other._address, _address);
-   TargetType overlap_end = std::min(other._endAddress, _endAddress);
-   uint64_t overlap = (uint64_t)overlap_end - (uint64_t)overlap_start + 1;
-   return this->overlap(other) ? overlap : 0;
+   void* overlap_start = std::max((void*)other._address, (void*)_address);
+   void* overlap_end = std::min((void*)other._endAddress, (void*)_endAddress);
+   std::pair<void*, void*> const range(overlap_start, overlap_end);
+   return this->overlap(other) ? range : std::pair<void*, void*>(NULL, NULL);
 }
 
 inline BaseDependency* DepsRegion::clone() const

--- a/src/support/depsregion.hpp
+++ b/src/support/depsregion.hpp
@@ -60,7 +60,8 @@ inline uint64_t DepsRegion::overlapSize ( const DepsRegion &other ) const
 {
    TargetType overlap_start = std::max(other._address, _address);
    TargetType overlap_end = std::min(other._endAddress, _endAddress);
-   return (uint64_t)overlap_end - (uint64_t)overlap_start;
+   uint64_t overlap = (uint64_t)overlap_end - (uint64_t)overlap_start + 1;
+   return this->overlap(other) ? overlap : 0;
 }
 
 inline BaseDependency* DepsRegion::clone() const

--- a/src/support/depsregion_decl.hpp
+++ b/src/support/depsregion_decl.hpp
@@ -87,7 +87,7 @@ namespace nanos {
          
          bool operator< ( const DepsRegion &obj ) const;
 
-         uint64_t overlapSize( const DepsRegion &obj ) const;
+         std::pair<void*, void*> getOverlapRange( const DepsRegion &obj ) const;
 
          //! \brief Returns dependence base address
          virtual void * getAddress () const;

--- a/src/support/depsregion_decl.hpp
+++ b/src/support/depsregion_decl.hpp
@@ -87,6 +87,8 @@ namespace nanos {
          
          bool operator< ( const DepsRegion &obj ) const;
 
+         uint64_t overlapSize( const DepsRegion &obj ) const;
+
          //! \brief Returns dependence base address
          virtual void * getAddress () const;
          

--- a/src/support/depsregion_decl.hpp
+++ b/src/support/depsregion_decl.hpp
@@ -87,7 +87,7 @@ namespace nanos {
          
          bool operator< ( const DepsRegion &obj ) const;
 
-         std::pair<void*, void*> getOverlapRange( const DepsRegion &obj ) const;
+         std::pair<void*, void*> computeOverlap( const DepsRegion &obj ) const;
 
          //! \brief Returns dependence base address
          virtual void * getAddress () const;


### PR DESCRIPTION
The branch contains an instrumentation plugin for nanox (based on tdg) developed for the task graph analysis portion of the legato project.

Summary of changes:
- Added a new instrumentation plugin
- Added the PAPI library as optional dependence to the build system (required for for the plugin)
- Changes to the nanox internals to facilitate the extraction of data sizes for graph edges

Features:
- User specified PAPI counters
- Json output for importing task-graph output into other tools
- Optional verbose PDF output with counters and edge weights visible
- A fix to the cregions dependency plugin from my other pull request [here](https://github.com/bsc-pm/nanox/pull/9)

This branch is a work in progress, some stuff still needs doing:
- Handling of commutative and concurrent sections when outputting json (at the moment it will just exit with a message if they are encountered)